### PR TITLE
Specify Node version

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Run Locally
 
-**Prerequisites:** Node.js
+**Prerequisites:** Node.js (поддерживаются версии 16 и выше)
 
 1. Install dependencies:
    `npm install`

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "engines": {
+    "node": ">=16"
+  },
   "scripts": {
     "dev": "vite",
     "build": "vite build",


### PR DESCRIPTION
## Summary
- specify Node >=16 in package.json
- document supported Node version in prerequisites

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any)*

------
https://chatgpt.com/codex/tasks/task_e_6845b8559294832eaf886f42d034af94