### PR TITLE
Fix ts-node ESM server run

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest",
     "lint": "eslint . --ext .ts,.tsx",
     "format": "prettier -w .",
-    "server": "ts-node server/index.ts",
+    "server": "ts-node --esm server/index.ts",
     "dev:all": "concurrently \"npm run dev\" \"npm run server\"",
     "postinstall": "npm rebuild rollup"
   },


### PR DESCRIPTION
## Summary
- enable ESM support for ts-node when starting the server

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845b952b150832eaf3d5dd19bfcd1bc