### PR TITLE
Add extended logging to Vite config

### DIFF
--- a/plugins/extendedLogger.ts
+++ b/plugins/extendedLogger.ts
@@ -1,0 +1,24 @@
+import type { Plugin } from 'vite';
+
+export default function extendedLogger(): Plugin {
+  return {
+    name: 'extended-logger',
+    config(config, { command }) {
+      console.info(`[vite] запуск команды: ${command}`);
+      console.info(`[vite] корневая папка: ${config.root || process.cwd()}`);
+    },
+    configureServer(server) {
+      server.httpServer?.once('listening', () => {
+        const info = server.httpServer?.address();
+        if (typeof info === 'object' && info) {
+          const host = info.address === '::' ? 'localhost' : info.address;
+          const protocol = server.config.server.https ? 'https' : 'http';
+          console.info(`[vite] сервер запущен: ${protocol}://${host}:${info.port}`);
+        }
+      });
+    },
+    buildEnd() {
+      console.info('[vite] сборка завершена');
+    },
+  };
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,12 @@
 import path from 'path';
 import { defineConfig, loadEnv } from 'vite';
+import extendedLogger from './plugins/extendedLogger';
 
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, '.', '');
   return {
+    plugins: [extendedLogger()],
+    logLevel: 'info',
     define: {
       'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
       'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY),


### PR DESCRIPTION
## Summary
- add extended logging plugin for Vite
- use plugin in `vite.config.ts`
- enable info level logging

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846feffc780832e892992fc7c472813