### PR TITLE
Add debug logging

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -6,7 +6,10 @@ import App from './App';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { AuthProvider } from './contexts/AuthContext';
 import { ToastProvider } from './components/ToastProvider';
+import { setupDebug } from './utils/debug';
 import './index.css';
+
+setupDebug();
 
 const savedTheme = localStorage.getItem('theme');
 if (savedTheme) {

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,11 +1,22 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import express from 'express';
+import type { Request, Response, NextFunction } from 'express';
 import rateLimit from 'express-rate-limit';
 import session from 'express-session';
 import { ApolloServer, gql } from 'apollo-server-express';
 import swaggerUi from 'swagger-ui-express';
 import swaggerJsdoc from 'swagger-jsdoc';
 import OAuth2Server from 'oauth2-server';
+
+process.on('uncaughtException', (err) => {
+  console.error('Uncaught Exception:', err);
+});
+process.on('unhandledRejection', (reason) => {
+  console.error('Unhandled Rejection:', reason);
+});
+process.on('warning', (warning) => {
+  console.warn(warning.name, warning.message, warning.stack);
+});
 
 const app = express();
 app.use(express.json());
@@ -278,6 +289,11 @@ app.get('/api/billing', (_req, res) => {
     },
   ];
   res.json({ tariffs, billing, history });
+});
+
+app.use((err: unknown, _req: Request, res: Response, _next: NextFunction) => {
+  console.error('Express error:', err);
+  res.status(500).json({ error: 'Internal Server Error' });
 });
 
 const PORT = process.env.PORT || 3001;

--- a/utils/debug.ts
+++ b/utils/debug.ts
@@ -1,0 +1,14 @@
+export function setupDebug(): void {
+  window.addEventListener('error', (event) => {
+    console.error('Global error:', event.error || event.message);
+  });
+
+  window.addEventListener('unhandledrejection', (event) => {
+    console.error('Unhandled promise rejection:', event.reason);
+  });
+
+  const originalWarn = console.warn;
+  console.warn = (...args: unknown[]): void => {
+    originalWarn(...args);
+  };
+}


### PR DESCRIPTION
## Summary
- add new `setupDebug` helper with global listeners
- use `setupDebug` in the frontend
- log uncaught errors on the server
- provide Express error middleware

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684700e75f88832ea861d1ecdcfed5a6