### PR TITLE
Fix slug service and customization page

### DIFF
--- a/pages/ProfileCustomizationPage.tsx
+++ b/pages/ProfileCustomizationPage.tsx
@@ -8,10 +8,13 @@ import { RichTextEditor } from '../components/RichTextEditor';
 import { ProfileLayoutSelector } from '../components/ProfileLayoutSelector';
 import { Toast } from '../components/Toast';
 import { fetchProfile, saveProfile, ProfileData } from '../services/profileService';
+import { useSlugValidation } from '../hooks/useSlugValidation';
+import { registerSlug } from '../services/slugService';
 import { Button } from '../ui/Button';
 import Spinner from '../ui/Spinner';
 import { DragDropContext, Droppable, Draggable, DropResult } from 'react-beautiful-dnd';
 
+const RESERVED_SLUGS = ['admin', 'login', 'me', 'profile'];
 const BLOCK_TYPES = [
   { type: 'button', label: 'Кнопка', default: { text: 'Ссылка', url: '#', style: 'primary' } },
   { type: 'text', label: 'Текст', default: { text: 'Новый текст' } },
@@ -52,6 +55,10 @@ const ProfileCustomizationPage: React.FC = () => {
     setProfile((p) => ({ ...p, blocks: p.blocks.filter((_, i) => i !== index) }));
   };
 
+  const updateBlock = (
+    index: number,
+    props: Partial<{ text?: string; url?: string; style?: string }>
+  ) => {
     setProfile((p) => ({
       ...p,
       blocks: p.blocks.map((b, i) => (i === index ? { ...b, ...props } : b)),
@@ -69,7 +76,7 @@ const ProfileCustomizationPage: React.FC = () => {
   const handleSave = async () => {
     if (!slugValid) {
       setToast('Некорректный адрес профиля');
-      return;}
+      return; }
     setSaving(true);
     try {
       await saveProfile(profile);
@@ -174,7 +181,9 @@ const ProfileCustomizationPage: React.FC = () => {
         </aside>
         <main className="flex-1 bg-white rounded-xl border shadow p-6">
           <div className="overflow-hidden rounded-xl border mb-6">
-            {profile.cover && <img src={profile.cover} alt="cover" className="w-full h-32 object-cover" />}
+            {profile.cover && (
+              <img src={profile.cover} alt="cover" className="w-full h-32 object-cover" />
+            )}
             <div className="p-4 text-center relative">
               {profile.avatar && (
                 <img

--- a/services/slugService.ts
+++ b/services/slugService.ts
@@ -5,4 +5,16 @@ const checkResponse = z.object({ unique: z.boolean() });
 const registerResponse = z.object({ success: z.boolean() });
 
 export async function checkSlugUnique(slug: string): Promise<{ unique: boolean }> {
+  return fetchJson(
+    `/api/check-slug?slug=${encodeURIComponent(slug)}`,
+    checkResponse
+  );
+}
+
+export async function registerSlug(slug: string): Promise<{ success: boolean }> {
+  return fetchJson(
+    '/api/register-slug',
+    registerResponse,
+    { method: 'POST', body: { slug } }
+  );
 }


### PR DESCRIPTION
## Summary
- implement slug API helpers
- restore imports and util functions for profile customization page
- ensure proper closure of JSX markup

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68470c89dac0832eb032995cb5450c03