### PR TITLE
Fix slug API integration

### DIFF
--- a/hooks/useSlugValidation.ts
+++ b/hooks/useSlugValidation.ts
@@ -15,8 +15,8 @@ export function useSlugValidation(slug: string, reserved: string[] = []) {
     }
     let cancelled = false;
     checkSlugUnique(slug)
-      .then(r => {
-        if (!cancelled) setValid(r.unique);
+      .then((r) => {
+        if (!cancelled) setValid(r.available);
       })
       .catch(() => {
         if (!cancelled) setValid(false);

--- a/pages/ProfileCustomizationPage.tsx
+++ b/pages/ProfileCustomizationPage.tsx
@@ -8,10 +8,13 @@ import { RichTextEditor } from '../components/RichTextEditor';
 import { ProfileLayoutSelector } from '../components/ProfileLayoutSelector';
 import { Toast } from '../components/Toast';
 import { fetchProfile, saveProfile, ProfileData } from '../services/profileService';
+import { useSlugValidation } from '../hooks/useSlugValidation';
+import { registerSlug } from '../services/slugService';
 import { Button } from '../ui/Button';
 import Spinner from '../ui/Spinner';
 import { DragDropContext, Droppable, Draggable, DropResult } from 'react-beautiful-dnd';
 
+const RESERVED_SLUGS = ['admin', 'login', 'me', 'profile'];
 const BLOCK_TYPES = [
   { type: 'button', label: 'Кнопка', default: { text: 'Ссылка', url: '#', style: 'primary' } },
   { type: 'text', label: 'Текст', default: { text: 'Новый текст' } },
@@ -52,6 +55,10 @@ const ProfileCustomizationPage: React.FC = () => {
     setProfile((p) => ({ ...p, blocks: p.blocks.filter((_, i) => i !== index) }));
   };
 
+  const updateBlock = (
+    index: number,
+    props: Partial<{ text?: string; url?: string; style?: string }>
+  ) => {
     setProfile((p) => ({
       ...p,
       blocks: p.blocks.map((b, i) => (i === index ? { ...b, ...props } : b)),
@@ -69,7 +76,7 @@ const ProfileCustomizationPage: React.FC = () => {
   const handleSave = async () => {
     if (!slugValid) {
       setToast('Некорректный адрес профиля');
-      return;}
+      return; }
     setSaving(true);
     try {
       await saveProfile(profile);
@@ -174,7 +181,9 @@ const ProfileCustomizationPage: React.FC = () => {
         </aside>
         <main className="flex-1 bg-white rounded-xl border shadow p-6">
           <div className="overflow-hidden rounded-xl border mb-6">
-            {profile.cover && <img src={profile.cover} alt="cover" className="w-full h-32 object-cover" />}
+            {profile.cover && (
+              <img src={profile.cover} alt="cover" className="w-full h-32 object-cover" />
+            )}
             <div className="p-4 text-center relative">
               {profile.avatar && (
                 <img

--- a/server/index.ts
+++ b/server/index.ts
@@ -142,6 +142,20 @@ app.get('/api/check-slug', (req, res) => {
   res.status(available ? 200 : 409).json({ available });
 });
 
+app.post('/api/register-slug', (req, res) => {
+  const slug = String(req.body.slug || '').toLowerCase();
+  if (!slug) {
+    res.status(400).json({ error: 'Missing slug' });
+    return;
+  }
+  if (RESERVED_SLUGS.has(slug) || usedSlugs.has(slug)) {
+    res.status(409).json({ success: false });
+    return;
+  }
+  usedSlugs.add(slug);
+  res.json({ success: true });
+});
+
 // GraphQL setup
 const typeDefs = gql`
   type Query {

--- a/services/profile.ts
+++ b/services/profile.ts
@@ -1,13 +1,13 @@
 import { z } from 'zod';
 import { fetchJson } from './api';
 
-export const SlugCheckResponse = z.object({ unique: z.boolean() });
+export const SlugCheckResponse = z.object({ available: z.boolean() });
 
 export async function checkSlugUnique(slug: string) {
   // Placeholder API call
   const url = `/api/check-slug?slug=${encodeURIComponent(slug)}`;
   const res = await fetchJson(url, SlugCheckResponse);
-  return res.unique;
+  return res.available;
 }
 
 export async function publishProfile(slug: string, data: unknown) {

--- a/services/slugService.ts
+++ b/services/slugService.ts
@@ -1,8 +1,20 @@
 import { z } from 'zod';
 import { fetchJson } from './api';
 
-const checkResponse = z.object({ unique: z.boolean() });
+const checkResponse = z.object({ available: z.boolean() });
 const registerResponse = z.object({ success: z.boolean() });
 
-export async function checkSlugUnique(slug: string): Promise<{ unique: boolean }> {
+export async function checkSlugUnique(slug: string): Promise<{ available: boolean }> {
+  return fetchJson(
+    `/api/check-slug?slug=${encodeURIComponent(slug)}`,
+    checkResponse
+  );
+}
+
+export async function registerSlug(slug: string): Promise<{ success: boolean }> {
+  return fetchJson(
+    '/api/register-slug',
+    registerResponse,
+    { method: 'POST', body: { slug } }
+  );
 }


### PR DESCRIPTION
## Summary
- add `/api/register-slug` endpoint on the server
- align slug service with server responses
- update slug validation hook
- adjust profile service slug check

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68470c89dac0832eb032995cb5450c03