### PR TITLE
fix comments confirm deletion

### DIFF
--- a/components/Comments.tsx
+++ b/components/Comments.tsx
@@ -7,8 +7,22 @@ export const Comments: React.FC = () => {
 
   const submit = () => {
     if (text.trim()) {
-      comment(text.trim().slice(0, 140));
-      setText('');
+      try {
+        comment(text.trim().slice(0, 140));
+        setText('');
+      } catch (e) {
+        console.error(e);
+      }
+    }
+  };
+
+  const handleRemove = (id: number) => {
+    if (window.confirm('Удалить комментарий?')) {
+      try {
+        removeComment(id);
+      } catch (e) {
+        console.error(e);
+      }
     }
   };
 
@@ -27,14 +41,14 @@ export const Comments: React.FC = () => {
         </button>
       </div>
       <ul className="space-y-1 text-sm">
-        {data.comments.map((c) => (
-          <li key={c.id} className="flex justify-between bg-gray-100 p-1 rounded">
-            <span>{c.text}</span>
-            <button onClick={() => removeComment(c.id)} className="text-red-600 ml-2">
-              удалить
-            </button>
-          </li>
-        ))}
+          {data.comments.map((c) => (
+            <li key={c.id} className="flex justify-between bg-gray-100 p-1 rounded">
+              <span>{c.text}</span>
+              <button onClick={() => handleRemove(c.id)} className="text-red-600 ml-2">
+                удалить
+              </button>
+            </li>
+          ))}
       </ul>
     </div>
   );


### PR DESCRIPTION
## Summary
- add error handling and delete confirmation in Comments component

## Testing
- `npm run lint`
- `npm run test` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_68489cad14a0832e9bb63d0c54451d98