### PR TITLE
Fix cropping error handling

### DIFF
--- a/components/CoverUploader.tsx
+++ b/components/CoverUploader.tsx
@@ -55,10 +55,15 @@ export const CoverUploader: React.FC<Props> = ({ onChange }) => {
 
   const saveCrop = useCallback(async () => {
     if (imageSrc && croppedAreaPixels) {
-      const cropped = await getCroppedImg(imageSrc, croppedAreaPixels);
-      setCover(cropped);
-      onChange?.(cropped);
-      setImageSrc(null);
+      try {
+        const cropped = await getCroppedImg(imageSrc, croppedAreaPixels);
+        setCover(cropped);
+        onChange?.(cropped);
+        setImageSrc(null);
+      } catch (e) {
+        console.error(e);
+        setError('Не удалось обработать изображение');
+      }
     }
   }, [imageSrc, croppedAreaPixels, onChange]);
 


### PR DESCRIPTION
## Summary
- catch errors when cropping cover images

## Testing
- `npm test` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_68489cb924d8832e9ca3bb2c608db2f3