### PR TITLE
Implement ViewMode context for header

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -6,9 +6,10 @@ import {
   MobileViewIcon,
 } from './icons/IconComponents';
 import { Tooltip } from './Tooltip';
+import { useViewMode } from '../contexts/ViewModeContext';
 
 export const Header: React.FC = () => {
-  const [isDesktopViewActive, setIsDesktopViewActive] = React.useState(true);
+  const { isDesktopView, setIsDesktopView } = useViewMode();
 
   return (
     <header className="bg-white/95 backdrop-blur-md border-b border-gray-200/50 py-3 shadow-sm">
@@ -17,6 +18,7 @@ export const Header: React.FC = () => {
           {/* Left: Logo */}
           <Link
             to="/"
+            aria-label="На главную"
             className="flex items-center p-[6px] bg-gradient-to-r from-gray-50 to-white rounded-[16px] space-x-3 hover:shadow-md transition-all duration-300 border border-gray-100"
           >
             <div className="flex items-center gap-[2px] px-[6px] py-[4px]">
@@ -33,10 +35,10 @@ export const Header: React.FC = () => {
               <button
                 id="view-toggle-desktop"
                 aria-label="Desktop view"
-                aria-pressed={isDesktopViewActive}
-                onClick={() => setIsDesktopViewActive(true)}
+                aria-pressed={isDesktopView}
+                onClick={() => setIsDesktopView(true)}
                 className={`p-[10px] rounded-[9px] transition-all duration-300 ${
-                  isDesktopViewActive
+                  isDesktopView
                     ? 'bg-white text-gray-900 shadow-sm border border-gray-200'
                     : 'text-gray-500 hover:bg-white/50 hover:text-gray-700'
                 }`}
@@ -47,10 +49,10 @@ export const Header: React.FC = () => {
             <Tooltip text="Мобильный режим">
               <button
                 aria-label="Mobile view"
-                aria-pressed={!isDesktopViewActive}
-                onClick={() => setIsDesktopViewActive(false)}
+                aria-pressed={!isDesktopView}
+                onClick={() => setIsDesktopView(false)}
                 className={`p-[10px] rounded-[9px] transition-all duration-300 ${
-                  !isDesktopViewActive
+                  !isDesktopView
                     ? 'bg-white text-gray-900 shadow-sm border border-gray-200'
                     : 'text-gray-500 hover:bg-white/50 hover:text-gray-700'
                 }`}
@@ -65,6 +67,7 @@ export const Header: React.FC = () => {
             <Tooltip text="Войти в аккаунт">
               <Link
                 to="/auth?action=login"
+                aria-label="Войти в аккаунт"
                 className="px-[16px] py-[8px] text-sm font-semibold text-gray-700 bg-white hover:bg-gray-50 rounded-[10px] transition-all duration-300 leading-[20px] shadow-sm border border-gray-200 hover:shadow-md"
               >
                 Войти
@@ -73,6 +76,7 @@ export const Header: React.FC = () => {
             <Tooltip text="Создать новый аккаунт">
               <Link
                 to="/auth?action=signup"
+                aria-label="Создать аккаунт"
                 className="px-[16px] py-[8px] text-sm font-semibold text-white bg-gradient-to-r from-blue-600 to-blue-700 hover:from-blue-700 hover:to-blue-800 rounded-[10px] transition-all duration-300 leading-[20px] shadow-md hover:shadow-lg"
               >
                 Регистрация

--- a/contexts/ViewModeContext.tsx
+++ b/contexts/ViewModeContext.tsx
@@ -1,0 +1,31 @@
+import React, { createContext, useContext, useState, useEffect } from 'react';
+
+interface ViewModeContextValue {
+  isDesktopView: boolean;
+  setIsDesktopView: (desktop: boolean) => void;
+}
+
+const ViewModeContext = createContext<ViewModeContextValue | undefined>(undefined);
+
+export const ViewModeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const getIsDesktop = () => (typeof window === 'undefined' ? true : window.innerWidth >= 1024);
+  const [isDesktopView, setIsDesktopView] = useState<boolean>(getIsDesktop);
+
+  useEffect(() => {
+    const handleResize = () => setIsDesktopView(getIsDesktop());
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  return (
+    <ViewModeContext.Provider value={{ isDesktopView, setIsDesktopView }}>
+      {children}
+    </ViewModeContext.Provider>
+  );
+};
+
+export const useViewMode = () => {
+  const ctx = useContext(ViewModeContext);
+  if (!ctx) throw new Error('useViewMode must be used within ViewModeProvider');
+  return ctx;
+};

--- a/index.tsx
+++ b/index.tsx
@@ -6,6 +6,7 @@ import App from './App';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { AuthProvider } from './contexts/AuthContext';
 import { ToastProvider } from './components/ToastProvider';
+import { ViewModeProvider } from './contexts/ViewModeContext';
 import { setupDebug } from './utils/debug';
 import './index.css';
 
@@ -32,11 +33,13 @@ root.render(
     <QueryClientProvider client={queryClient}>
       <BrowserRouter>
         <AuthProvider>
-          <ToastProvider>
-            <ErrorBoundary>
-              <App />
-            </ErrorBoundary>
-          </ToastProvider>
+          <ViewModeProvider>
+            <ToastProvider>
+              <ErrorBoundary>
+                <App />
+              </ErrorBoundary>
+            </ToastProvider>
+          </ViewModeProvider>
         </AuthProvider>
       </BrowserRouter>
     </QueryClientProvider>


### PR DESCRIPTION
## Summary
- add global `ViewModeContext` to sync desktop/mobile state
- wrap app with `ViewModeProvider`
- update `Header` to use context and improve accessibility

## Testing
- `npm test` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_68489cd0752c832e899c31986c8ce7c9