### PR TITLE
Fix React import in BottomSheet

### DIFF
--- a/components/BottomSheet.tsx
+++ b/components/BottomSheet.tsx
@@ -1,5 +1,5 @@
 
-
+import React from 'react';
 interface Props {
   open: boolean;
   onClose: () => void;


### PR DESCRIPTION
## Summary
- add missing `React` import in `BottomSheet`

## Testing
- `npm test` *(fails: Cannot find module '@rollup/rollup-linux-x64-gnu')*

------
https://chatgpt.com/codex/tasks/task_e_68489f1b57ec832e9070ea6cb33e5a3e