### PR TITLE
Fix ButtonLinkEditor types

### DIFF
--- a/components/ButtonLinkEditor.tsx
+++ b/components/ButtonLinkEditor.tsx
@@ -9,7 +9,7 @@ interface Props {
   onUrlChange: (val: string) => void;
 }
 
-export const ButtonLinkEditor: React.FC<Props> = ({ value, url, onTextChange, onUrlChange }) => {
+export const ButtonLinkEditor = ({ value, url, onTextChange, onUrlChange }: Props) => {
   // Редактор кнопки-ссылки
   const [showPicker, setShowPicker] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -43,14 +43,14 @@ export const ButtonLinkEditor: React.FC<Props> = ({ value, url, onTextChange, on
       <input
         type="text"
         value={value}
-        onChange={(e) => onTextChange(e.target.value)}
+        onChange={(e: React.ChangeEvent<HTMLInputElement>) => onTextChange(e.target.value)}
         placeholder="Текст кнопки"
         className="border px-2 py-1 rounded w-full"
       />
       <input
         type="url"
         value={url}
-        onChange={(e) => handleUrlChange(e.target.value)}
+        onChange={(e: React.ChangeEvent<HTMLInputElement>) => handleUrlChange(e.target.value)}
         placeholder="https://example.com"
         className="border px-2 py-1 rounded w-full mt-1"
       />

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@supabase/supabase-js": "^2.39.3",
         "@tanstack/react-query": "^5.80.6",
         "apollo-server-express": "^3.13.0",
+        "emoji-picker-react": "^4.12.2",
         "express": "^4.19.2",
         "express-rate-limit": "^7.5.0",
         "express-session": "^1.17.3",
@@ -3034,6 +3035,21 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/emoji-picker-react": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/emoji-picker-react/-/emoji-picker-react-4.12.2.tgz",
+      "integrity": "sha512-6PDYZGlhidt+Kc0ay890IU4HLNfIR7/OxPvcNxw+nJ4HQhMKd8pnGnPn4n2vqC/arRFCNWQhgJP8rpsYKsz0GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "flairup": "1.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16"
+      }
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "license": "MIT"
@@ -3771,6 +3787,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/flairup": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/flairup/-/flairup-1.0.0.tgz",
+      "integrity": "sha512-IKlE+pNvL2R+kVL1kEhUYqRxVqeFnjiIvHWDMLFXNaqyUdFXQM2wte44EfMYJNHkW16X991t2Zg8apKkhv7OBA==",
+      "license": "MIT"
     },
     "node_modules/flat-cache": {
       "version": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@supabase/supabase-js": "^2.39.3",
     "@tanstack/react-query": "^5.80.6",
     "apollo-server-express": "^3.13.0",
+    "emoji-picker-react": "^4.12.2",
     "express": "^4.19.2",
     "express-rate-limit": "^7.5.0",
     "express-session": "^1.17.3",


### PR DESCRIPTION
## Summary
- add missing `emoji-picker-react` dependency
- fix `ButtonLinkEditor` props typing and event handler types

## Testing
- `npm test` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_68489f2f94d8832ea443570b3a5376b7