### PR TITLE
fix: enforce object type for profile publish

### DIFF
--- a/components/PublishProfileButton.tsx
+++ b/components/PublishProfileButton.tsx
@@ -4,7 +4,7 @@ import { useToast } from './ToastProvider';
 
 interface Props {
   slug: string;
-  data: unknown;
+  data: Record<string, unknown>;
 }
 
 export const PublishProfileButton: React.FC<Props> = ({ slug, data }) => {

--- a/services/profile.ts
+++ b/services/profile.ts
@@ -10,7 +10,7 @@ export async function checkSlugUnique(slug: string) {
   return res.available;
 }
 
-export async function publishProfile(slug: string, data: unknown) {
+export async function publishProfile(slug: string, data: Record<string, unknown>) {
   const url = `/api/publish/${encodeURIComponent(slug)}`;
   await fetchJson(url, z.any(), { method: 'POST', body: data });
 }


### PR DESCRIPTION
## Summary
- fix type of `data` in `PublishProfileButton` and `publishProfile`

## Testing
- `npm test` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: parse errors in unrelated components)*

------
https://chatgpt.com/codex/tasks/task_e_6848a40e50d8832e9fe7ce82ea242faa