### PR TITLE
Fix slug validation hook

### DIFF
--- a/hooks/useSlugValidation.ts
+++ b/hooks/useSlugValidation.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { checkSlugUnique } from '../services/slugService';
+import { checkSlug } from '../services/slugService';
 
 export function useSlugValidation(slug: string, reserved: string[] = []) {
   const [valid, setValid] = useState<boolean | null>(null);
@@ -14,9 +14,9 @@ export function useSlugValidation(slug: string, reserved: string[] = []) {
       return;
     }
     let cancelled = false;
-    checkSlugUnique(slug)
-      .then((r) => {
-        if (!cancelled) setValid(r.available);
+    checkSlug(slug)
+      .then(({ available }) => {
+        if (!cancelled) setValid(available);
       })
       .catch(() => {
         if (!cancelled) setValid(false);


### PR DESCRIPTION
## Summary
- fix the slug service import in `useSlugValidation`
- return typed result from slug check

## Testing
- `npm test` *(fails: Cannot find module '@rollup/rollup-linux-x64-gnu')*

------
https://chatgpt.com/codex/tasks/task_e_6848a55993a8832e8a09b6778c52be39