### PR TITLE
Fix layout props on AccountSettingsPage

### DIFF
--- a/pages/AccountSettingsPage.tsx
+++ b/pages/AccountSettingsPage.tsx
@@ -108,7 +108,6 @@ const AccountSettingsPage: React.FC = () => {
     newPassword: '',
     confirmPassword: '',
   });
-  const [avatarFile, setAvatarFile] = useState<File | null>(null);
 
   useEffect(() => {
     if (!authLoading && !isAuthenticated) {
@@ -317,14 +316,7 @@ const AccountSettingsPage: React.FC = () => {
   }
 
   return (
-    <StandardPageLayout
-      title="Настройки аккаунта"
-      description="Управление профилем, безопасностью и настройками аккаунта"
-      breadcrumbs={[
-        { label: 'Главная', href: '/' },
-        { label: 'Настройки аккаунта', href: '/account/settings' },
-      ]}
-    >
+    <StandardPageLayout title="Настройки аккаунта">
       <div className="max-w-4xl mx-auto space-y-8">
         <SectionCard title="Основная информация" loading={saving.profile} error={errors.profile}>
           {success.profile && <SuccessMessage message={success.profile} />}


### PR DESCRIPTION
## Summary
- remove unused avatar file state
- drop unsupported description/breadcrumb props from StandardPageLayout

## Testing
- `npm run lint` *(fails: BottomSheet prop-types)*
- `npm test` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_6848a56b33a0832ea132050df8cb3586