### PR TITLE
Fix admin page role check

### DIFF
--- a/pages/AdminPage.tsx
+++ b/pages/AdminPage.tsx
@@ -1,5 +1,5 @@
 // Админ-панель
-import React, { useEffect } from 'react';
+import React from 'react';
 import StandardPageLayout from '../layouts/StandardPageLayout';
 import { Link } from 'react-router-dom';
 import useAuth from '../hooks/useAuth';
@@ -22,7 +22,8 @@ const AdminSectionLink: React.FC<{
 );
 
 const AdminPage: React.FC = () => {
-
+  const { user } = useAuth();
+  const isStaff = user?.role === 'staff' || user?.role === 'owner';
 
   if (!isStaff) {
     return (


### PR DESCRIPTION
## Summary
- use `useAuth` to determine staff access
- remove unused `useEffect` import

## Testing
- `npm test` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_6848a57246dc832e808e01090efaa1e5