### PR TITLE
Fix TypeScript error in AiDemoPage

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -20,6 +20,7 @@
     "react/no-unescaped-entities": "off",
     "@typescript-eslint/no-unused-vars": "off",
     "no-undef": "off",
-    "react/react-in-jsx-scope": "off"
+    "react/react-in-jsx-scope": "off",
+    "react/prop-types": "off"
   }
 }

--- a/pages/AiDemoPage.tsx
+++ b/pages/AiDemoPage.tsx
@@ -94,7 +94,7 @@ const AiDemoPage: React.FC = () => {
             {loading && <Spinner size="h-4 w-4" className="mr-2" />}
             {loading ? 'AI генерирует…' : 'Сгенерировать'}
           </Button>
-          {error && (
+          {Boolean(error) && (
             <div className="flex items-center gap-2 text-red-600 mt-2">
               <svg viewBox="0 0 20 20" fill="currentColor" className="w-5 h-5">
                 <path fillRule="evenodd" d="M18 10A8 8 0 11..." clipRule="evenodd" />


### PR DESCRIPTION
## Summary
- fix conditional render logic in `AiDemoPage`
- disable `react/prop-types` in ESLint config to silence TypeScript prop-type warnings

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot find module '@rollup/rollup-linux-x64-gnu')*

------
https://chatgpt.com/codex/tasks/task_e_6848a579e178832eb41f39892a4cc069