### PR TITLE
Fix TypeScript errors in AuthPage

### DIFF
--- a/pages/AuthPage.tsx
+++ b/pages/AuthPage.tsx
@@ -90,7 +90,7 @@ const AuthPage: React.FC = () => {
         setSuccessMsg('Письмо для восстановления отправлено на почту.');
       }
     } catch (err: unknown) {
-      setErrorMsg(message);
+      setErrorMsg(err instanceof Error ? err.message : 'Unknown error');
     }
   };
 
@@ -160,7 +160,7 @@ const AuthPage: React.FC = () => {
                 type={showPassword ? 'text' : 'password'}
                 id="password"
                 name="password"
-                required={mode !== 'reset'}
+                required
                 value={fields.password}
                 onChange={handleChange}
                 className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm pr-10"


### PR DESCRIPTION
## Summary
- handle caught errors correctly
- simplify password input `required` attribute

## Testing
- `npm test` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_6848a58480d4832e95bf2c38c9ffaec5