### PR TITLE
Fix PaymentHistory item link property

### DIFF
--- a/pages/BillingPage.tsx
+++ b/pages/BillingPage.tsx
@@ -94,7 +94,7 @@ const PaymentHistoryRow = ({
   amount,
   status,
   invoiceId,
-  link,
+  invoiceLink,
 }: PaymentHistoryItem) => (
   <tr className="border-b border-gray-200 hover:bg-gray-50 text-sm">
     <td className="py-3 px-4 text-gray-700">{date}</td>
@@ -113,8 +113,8 @@ const PaymentHistoryRow = ({
       </span>
     </td>
     <td className="py-3 px-4">
-      {link ? (
-        <a href={link} className="text-indigo-600 hover:underline" target="_blank" rel="noopener noreferrer">
+      {invoiceLink ? (
+        <a href={invoiceLink} className="text-indigo-600 hover:underline" target="_blank" rel="noopener noreferrer">
           #{invoiceId}
         </a>
       ) : (


### PR DESCRIPTION
## Summary
- use `invoiceLink` field from `PaymentHistoryItem`

## Testing
- `npm test` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_6848a58ac96c832ea855d67140ed5cdb