### PR TITLE
Fix block typing in EditorPage

### DIFF
--- a/pages/EditorPage.tsx
+++ b/pages/EditorPage.tsx
@@ -7,7 +7,7 @@ import { useToast } from '../components/ToastProvider';
 import Spinner from '../ui/Spinner';
 
 // --- Базовые типы блоков ---
-const BLOCK_TYPES = [
+const BLOCK_TYPES: { type: BlockType; label: string }[] = [
   { type: 'text', label: 'Текст' },
   { type: 'image', label: 'Изображение' },
   { type: 'button', label: 'Кнопка' },
@@ -25,11 +25,63 @@ const DEFAULT_BLOCK_PROPS = {
   map: { address: '' },
 };
 
-interface Block {
+type BlockType = keyof typeof DEFAULT_BLOCK_PROPS;
+
+interface TextBlock {
   id: string;
-  type: string;
-  props: Record<string, unknown>;
+  type: 'text';
+  props: {
+    text: string;
+    color: string;
+    bg: string;
+    font: string;
+  };
 }
+
+interface ImageBlock {
+  id: string;
+  type: 'image';
+  props: {
+    src: string;
+    alt: string;
+  };
+}
+
+interface ButtonBlock {
+  id: string;
+  type: 'button';
+  props: {
+    text: string;
+    color: string;
+    bg: string;
+  };
+}
+
+interface VideoBlock {
+  id: string;
+  type: 'video';
+  props: {
+    url: string;
+  };
+}
+
+interface FormBlock {
+  id: string;
+  type: 'form';
+  props: {
+    fields: string[];
+  };
+}
+
+interface MapBlock {
+  id: string;
+  type: 'map';
+  props: {
+    address: string;
+  };
+}
+
+type Block = TextBlock | ImageBlock | ButtonBlock | VideoBlock | FormBlock | MapBlock;
 
 // --- Undo/Redo стэк ---
 function useUndoRedo<T>(initial: T) {
@@ -87,11 +139,11 @@ const EditorPage: React.FC = () => {
   const nextId = useRef(1);
 
   // --- Добавить блок
-  const addBlock = (type: string) => {
+  const addBlock = (type: BlockType) => {
     const id = `b${nextId.current++}`;
     setBlocks([
       ...blocks,
-      { id, type, props: { ...DEFAULT_BLOCK_PROPS[type] } },
+      { id, type, props: { ...DEFAULT_BLOCK_PROPS[type] } } as Block,
     ]);
     setSelectedId(id);
   };
@@ -100,7 +152,7 @@ const EditorPage: React.FC = () => {
   const updateBlock = (id: string, newProps: Record<string, unknown>) => {
     setBlocks(
       blocks.map((b) =>
-        b.id === id ? { ...b, props: { ...b.props, ...newProps } } : b
+        b.id === id ? ({ ...b, props: { ...b.props, ...newProps } } as Block) : b
       )
     );
   };


### PR DESCRIPTION
## Summary
- define block types with strict interfaces
- fix addBlock and updateBlock functions

## Testing
- `npm test` *(fails: Cannot find module `@rollup/rollup-linux-x64-gnu`)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: several typing errors remain outside EditorPage)*

------
https://chatgpt.com/codex/tasks/task_e_6848a5938328832ea63a94c53ab17b3b