### PR TITLE
Fix unused index and disable prop-types rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -20,6 +20,7 @@
     "react/no-unescaped-entities": "off",
     "@typescript-eslint/no-unused-vars": "off",
     "no-undef": "off",
-    "react/react-in-jsx-scope": "off"
+    "react/react-in-jsx-scope": "off",
+    "react/prop-types": "off"
   }
 }

--- a/pages/HomePage.tsx
+++ b/pages/HomePage.tsx
@@ -222,7 +222,7 @@ const HomePage: React.FC = () => {
             </div>
           ) : (
             <div className="grid md:grid-cols-3 gap-8">
-              {cases.slice(0, 3).map((c, index) => (
+              {cases.slice(0, 3).map((c) => (
                 <div key={c.id} className="group bg-white rounded-2xl overflow-hidden shadow-lg hover:shadow-2xl transition-all duration-300 hover:-translate-y-2">
                   <div className="relative overflow-hidden">
                     <img


### PR DESCRIPTION
## Summary
- исправлена неиспользуемая переменная `index`
- отключено правило `react/prop-types` в ESLint

## Testing
- `npm run lint`
- `npm test` *(падает: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_6848a59ba950832eae84681aa6955ed7