### PR TITLE
Fix StandardPageLayout props

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -20,6 +20,7 @@
     "react/no-unescaped-entities": "off",
     "@typescript-eslint/no-unused-vars": "off",
     "no-undef": "off",
-    "react/react-in-jsx-scope": "off"
+    "react/react-in-jsx-scope": "off",
+    "react/prop-types": "off"
   }
 }

--- a/layouts/StandardPageLayout.tsx
+++ b/layouts/StandardPageLayout.tsx
@@ -1,13 +1,42 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 
-const StandardPageLayout: React.FC<{
-  // Стандартный макет страницы
+export interface Breadcrumb {
+  label: string;
+  href: string;
+}
+
+interface StandardPageLayoutProps {
+  /** Заголовок страницы */
   title: string;
+  /** Дополнительное описание под заголовком */
+  description?: string;
+  /** Хлебные крошки навигации */
+  breadcrumbs?: Breadcrumb[];
   children?: React.ReactNode;
-}> = ({ title, children }) => (
+}
+
+const StandardPageLayout: React.FC<StandardPageLayoutProps> = ({
+  title,
+  description,
+  breadcrumbs,
+  children,
+}) => (
   <div className="main-content-area">
-    <h1 className="text-3xl font-bold mb-4 font-pragmatica">{title}</h1>
+    {breadcrumbs && (
+      <nav className="text-sm text-gray-500 mb-2" aria-label="Breadcrumb">
+        {breadcrumbs.map((crumb, idx) => (
+          <span key={crumb.href}>
+            <Link to={crumb.href} className="hover:underline">
+              {crumb.label}
+            </Link>
+            {idx < breadcrumbs.length - 1 && ' / '}
+          </span>
+        ))}
+      </nav>
+    )}
+    <h1 className="text-3xl font-bold mb-2 font-pragmatica">{title}</h1>
+    {description && <p className="text-gray-600 mb-4">{description}</p>}
     {children || <p>Content for {title} will go here.</p>}
     <div className="mt-8">
       <h2 className="text-xl font-semibold mb-2">Quick Navigation:</h2>


### PR DESCRIPTION
## Summary
- extend StandardPageLayout to support description and breadcrumbs
- disable prop-types rule in ESLint so TS types satisfy linting

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_6848a5b5e694832e829b659e1dc657fe