### PR TITLE
Fix imports in PublicProfilePage

### DIFF
--- a/pages/PublicProfilePage.tsx
+++ b/pages/PublicProfilePage.tsx
@@ -1,5 +1,7 @@
 // Публичный профиль
 
+import React, { useState } from 'react';
+import { useParams } from 'react-router-dom';
 import { ProfileSidebar } from '../components/ProfileSidebar';
 import { ProjectShowcaseGrid } from '../components/ProjectShowcaseGrid';
 import { PublishProfileButton } from '../components/PublishProfileButton';
@@ -17,7 +19,6 @@ import {
   WindowFilesIcon,
 } from '../components/icons/IconComponents';
 import type { ShareActionItem } from '../types';
-import { fetchProfile } from '../services/profileService';
 
 // This component now represents Section 5: Public Page
 
@@ -123,6 +124,7 @@ const BottomRightShareBar: React.FC = () => {
 };
 
 const PublicProfilePage: React.FC = () => {
+  const { slug = '' } = useParams<{ slug: string }>();
   return (
     // main-content-area class gives the white bg and padding
     <div className="main-content-area relative flex flex-col md:flex-row gap-[80px]">


### PR DESCRIPTION
## Summary
- исправлен список импорта в PublicProfilePage
- добавлено получение `slug` из параметров маршрута

## Testing
- `npm run test` *(провалено: отсутствует модуль rollup)*
- `npx tsc -p tsconfig.json --noEmit` *(провалено: множественные ошибки типов)*

------
https://chatgpt.com/codex/tasks/task_e_6848a5bc8fb8832e9ab8901cd308dcbc