### PR TITLE
Fix BottomSheet hooks and update tests

### DIFF
--- a/__tests__/App.test.tsx
+++ b/__tests__/App.test.tsx
@@ -4,16 +4,17 @@ import { describe, it, expect } from 'vitest';
 import '@testing-library/jest-dom';
 import { MemoryRouter } from 'react-router-dom';
 import App from '../App';
+import { ViewModeProvider } from '../contexts/ViewModeContext';
 
 describe('App', () => {
   it('renders without crashing', () => {
     render(
       <MemoryRouter>
-        <App />
+        <ViewModeProvider>
+          <App />
+        </ViewModeProvider>
       </MemoryRouter>
     );
-    expect(
-      screen.getByText(/умный бенто‑конструктор/i)
-    ).toBeInTheDocument();
+    expect(screen.getByText(/умный бенто‑конструктор/i)).toBeInTheDocument();
   });
 });

--- a/__tests__/routes.test.tsx
+++ b/__tests__/routes.test.tsx
@@ -3,12 +3,15 @@ import { MemoryRouter } from 'react-router-dom';
 import { describe, it, expect } from 'vitest';
 import '@testing-library/jest-dom';
 import App from '../App';
+import { ViewModeProvider } from '../contexts/ViewModeContext';
 
 describe('routes configuration', () => {
   it('renders 404 page for unknown routes', () => {
     render(
       <MemoryRouter initialEntries={['/unknown']}>
-        <App />
+        <ViewModeProvider>
+          <App />
+        </ViewModeProvider>
       </MemoryRouter>
     );
     expect(

--- a/components/BottomSheet.tsx
+++ b/components/BottomSheet.tsx
@@ -1,3 +1,5 @@
+import React, { useState, useEffect } from 'react';
+
 interface Props {
   open: boolean;
   onClose: () => void;


### PR DESCRIPTION
## Summary
- импортировали useState/useEffect в BottomSheet
- обернули тесты ViewModeProvider

## Testing
- `npx eslint .`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6848a824f848832eb5070677eb596d05