### PR TITLE
Fix missing imports in PersonalizationPage

### DIFF
--- a/pages/PersonalizationPage.tsx
+++ b/pages/PersonalizationPage.tsx
@@ -6,6 +6,9 @@ import { CoverUploader } from '../components/CoverUploader';
 import { SlugEditor } from '../components/SlugEditor';
 import { ProfileLayoutSelector } from '../components/ProfileLayoutSelector';
 import { RichTextEditor } from '../components/RichTextEditor';
+import { useSlugValidation } from '../hooks/useSlugValidation';
+
+const RESERVED_SLUGS = ['admin', 'login', 'me', 'profile'];
 
 const PersonalizationPage: React.FC = () => {
   // Быстрая персонализация
@@ -45,6 +48,14 @@ const PersonalizationPage: React.FC = () => {
     <StandardPageLayout title="Редактор персонализации">
       <div className="flex flex-col lg:flex-row gap-6">
         <aside className="w-full lg:w-1/3 space-y-4">
+          <AvatarUploader onChange={setAvatarPreview} />
+          <CoverUploader onChange={setCoverPreview} />
+          <SlugEditor
+            value={slug}
+            onChange={(s) => setSlug(s.replace(/\s+/g, '-').toLowerCase())}
+            valid={slugValid}
+            base="https://basis.app/"
+          />
           <div className="space-y-4">
             {blocks.map((val, i) => (
               <div key={i}>
@@ -56,7 +67,10 @@ const PersonalizationPage: React.FC = () => {
               </div>
             ))}
           </div>
-          <ProfileLayoutSelector value={layout} onChange={setLayout} />
+          <ProfileLayoutSelector
+            value={layout}
+            onChange={(v) => setLayout(v as 'feed' | 'grid' | 'cards')}
+          />
         </aside>
         <main className="flex-1">
           <div className="border rounded overflow-hidden">


### PR DESCRIPTION
## Summary
- use avatar, cover and slug editor on personalization page
- import `useSlugValidation` and add reserved slugs constant

## Testing
- `npm test` *(fails: useViewMode must be used within ViewModeProvider)*

------
https://chatgpt.com/codex/tasks/task_e_6848a866bca4832e905672389630475e