### PR TITLE
Add validation utilities and UI checks

### DIFF
--- a/__tests__/validators.test.ts
+++ b/__tests__/validators.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { isValidEmail, isValidSlug, isValidUrl, isColorTooLight } from '../utils/validators';
+
+describe('validators', () => {
+  it('email validation', () => {
+    expect(isValidEmail('a@b.com')).toBe(true);
+    expect(isValidEmail('wrong')).toBe(false);
+  });
+
+  it('slug validation', () => {
+    expect(isValidSlug('abc-123')).toBe(true);
+    expect(isValidSlug('bad slug')).toBe(false);
+  });
+
+  it('url validation', () => {
+    expect(isValidUrl('https://example.com')).toBe(true);
+    expect(isValidUrl('ht!tp')).toBe(false);
+  });
+
+  it('color brightness', () => {
+    expect(isColorTooLight('#ffffff')).toBe(true);
+    expect(isColorTooLight('#000000')).toBe(false);
+  });
+});

--- a/components/ButtonLinkEditor.tsx
+++ b/components/ButtonLinkEditor.tsx
@@ -1,6 +1,7 @@
 // Редактор кнопки-ссылки
 import React, { useState } from 'react';
 import EmojiPicker, { EmojiClickData } from 'emoji-picker-react';
+import { isValidUrl } from '../utils/validators';
 
 interface Props {
   value: string;
@@ -14,15 +15,6 @@ export const ButtonLinkEditor = ({ value, url, onTextChange, onUrlChange }: Prop
   const [showPicker, setShowPicker] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const isValidUrl = (val: string) => {
-    try {
-      // eslint-disable-next-line no-new
-      new URL(val);
-      return true;
-    } catch {
-      return false;
-    }
-  };
 
   const handleEmoji = (emojiData: EmojiClickData) => {
     onTextChange(value + emojiData.emoji);

--- a/components/LiveEditor.tsx
+++ b/components/LiveEditor.tsx
@@ -1,10 +1,13 @@
 // Живой предпросмотр
 import React, { useState } from 'react';
+import { isColorTooLight, isValidText } from '../utils/validators';
 
 export const LiveEditor: React.FC = () => {
   // Живой предпросмотр
   const [title, setTitle] = useState('Заголовок профиля');
   const [color, setColor] = useState('#000000');
+  const titleValid = isValidText(title, 60);
+  const colorWarning = isColorTooLight(color);
 
   return (
     <div className="flex flex-col md:flex-row gap-4 h-full">
@@ -12,10 +15,14 @@ export const LiveEditor: React.FC = () => {
         <div>
           <label className="block text-sm font-semibold mb-1">Текст заголовка</label>
           <input
-            className="w-full p-2 border rounded"
+            className={`w-full p-2 border rounded ${titleValid ? '' : 'border-red-500'}`}
             value={title}
+            maxLength={60}
             onChange={(e) => setTitle(e.target.value)}
           />
+          {!titleValid && (
+            <p className="text-sm text-red-600">Введите заголовок</p>
+          )}
         </div>
         <div>
           <label className="block text-sm font-semibold mb-1">Цвет текста</label>
@@ -25,6 +32,9 @@ export const LiveEditor: React.FC = () => {
             value={color}
             onChange={(e) => setColor(e.target.value)}
           />
+          {colorWarning && (
+            <p className="text-sm text-orange-600">Слишком светлый цвет</p>
+          )}
         </div>
       </div>
       <div className="flex-1 flex items-center justify-center bg-gray-100 rounded">

--- a/components/ProfileEditor.tsx
+++ b/components/ProfileEditor.tsx
@@ -5,6 +5,7 @@ import { useAutosave } from '../hooks/useAutosave';
 import { UserProfile } from '../types';
 import { Button } from '../ui/Button';
 import { Toast } from './Toast';
+import { isValidEmail, isValidText } from '../utils/validators';
 
 interface Props {
   userId: string;
@@ -85,6 +86,11 @@ export const ProfileEditor: React.FC<Props> = ({
       set({ ...state, [field]: e.target.value });
     };
 
+  const validName = isValidText(state.name, 50);
+  const validEmail = isValidEmail(state.email);
+  const validBio = isValidText(state.bio, 200);
+  const canPublish = validName && validEmail && validBio;
+
   const handlePublish = () => {
     try {
       localStorage.setItem(`profile_${userId}`, JSON.stringify(state));
@@ -126,7 +132,9 @@ export const ProfileEditor: React.FC<Props> = ({
         <Button onClick={redo} disabled={!canRedo}>
           Redo
         </Button>
-        <Button onClick={handlePublish}>Сохранить</Button>
+        <Button onClick={handlePublish} disabled={!canPublish}>
+          Сохранить
+        </Button>
         <span className="text-sm text-gray-600">
           {saved ? 'изменения сохранены' : 'есть несохранённые изменения'}
         </span>
@@ -137,30 +145,41 @@ export const ProfileEditor: React.FC<Props> = ({
         >
           Имя
           <input
-            className="border p-2 w-full"
+            className={`border p-2 w-full ${validName ? '' : 'border-red-500'}`}
             value={state.name}
             onChange={handleChange('name')}
+            maxLength={50}
           />
+          {!validName && (
+            <span className="text-red-600 text-sm">Введите имя</span>
+          )}
         </label>
         <label
           className={`block ${isFieldChanged('email') ? 'bg-yellow-100' : ''}`}
         >
           Email
           <input
-            className="border p-2 w-full"
+            className={`border p-2 w-full ${validEmail ? '' : 'border-red-500'}`}
             value={state.email}
             onChange={handleChange('email')}
           />
+          {!validEmail && (
+            <span className="text-red-600 text-sm">Некорректный email</span>
+          )}
         </label>
         <label
           className={`block ${isFieldChanged('bio') ? 'bg-yellow-100' : ''}`}
         >
           Биография
           <textarea
-            className="border p-2 w-full h-24"
+            className={`border p-2 w-full h-24 ${validBio ? '' : 'border-red-500'}`}
             value={state.bio}
             onChange={handleChange('bio')}
+            maxLength={200}
           />
+          {!validBio && (
+            <span className="text-red-600 text-sm">Заполните биографию</span>
+          )}
         </label>
       </div>
       {toast && <Toast message={toast} onClose={() => setToast(null)} />}

--- a/pages/ProfileCustomizationPage.tsx
+++ b/pages/ProfileCustomizationPage.tsx
@@ -14,6 +14,7 @@ import { registerSlug } from '../services/slugService';
 import { Button } from '../ui/Button';
 import Spinner from '../ui/Spinner';
 import { DragDropContext, Droppable, Draggable, DropResult } from 'react-beautiful-dnd';
+import { isColorTooLight } from '../utils/validators';
 
 const RESERVED_SLUGS = ['admin', 'login', 'me', 'profile'];
 const BLOCK_TYPES = [
@@ -34,6 +35,7 @@ const ProfileCustomizationPage: React.FC = () => {
     blocks: [],
   });
   const slugValid = useSlugValidation(profile.slug, RESERVED_SLUGS);
+  const [lightColor, setLightColor] = useState(false);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [toast, setToast] = useState<string | null>(null);
@@ -168,12 +170,19 @@ const ProfileCustomizationPage: React.FC = () => {
               type="color"
               className="w-12 h-8 border rounded"
               value={profile.color}
-              onChange={(e) => setProfile((p) => ({ ...p, color: e.target.value }))}
+              onChange={(e) => {
+                const val = e.target.value;
+                setProfile((p) => ({ ...p, color: val }));
+                setLightColor(isColorTooLight(val));
+              }}
             />
+            {lightColor && (
+              <p className="text-sm text-orange-600">Цвет слишком светлый</p>
+            )}
           </div>
           <Button
             onClick={handleSave}
-            disabled={saving || !slugValid}
+            disabled={saving || !slugValid || lightColor}
             aria-busy={saving}
             className="mt-6 px-5 py-3 w-full bg-indigo-600 text-white rounded font-bold flex items-center justify-center"
           >

--- a/utils/validators.ts
+++ b/utils/validators.ts
@@ -1,0 +1,34 @@
+export const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+export const slugRegex = /^[a-zA-Z0-9-]+$/;
+
+export function isValidEmail(email: string): boolean {
+  return emailRegex.test(email);
+}
+
+export function isValidSlug(slug: string): boolean {
+  return slugRegex.test(slug);
+}
+
+export function isValidUrl(val: string): boolean {
+  try {
+    // eslint-disable-next-line no-new
+    new URL(val);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function isValidText(text: string, maxLength: number): boolean {
+  return text.trim().length > 0 && text.length <= maxLength;
+}
+
+export function isColorTooLight(color: string): boolean {
+  const hex = color.replace('#', '');
+  if (hex.length !== 6) return false;
+  const r = parseInt(hex.slice(0, 2), 16);
+  const g = parseInt(hex.slice(2, 4), 16);
+  const b = parseInt(hex.slice(4, 6), 16);
+  const brightness = (r * 299 + g * 587 + b * 114) / 1000;
+  return brightness > 240;
+}


### PR DESCRIPTION
## Summary
- validate emails, slugs, URLs and color brightness with new utilities
- highlight invalid fields in ProfileEditor and disable publish button
- warn about too light theme color on profile customization page
- improve LiveEditor inputs validation
- move URL validation in ButtonLinkEditor to shared util
- add unit tests for validation helpers

## Testing
- `npm test` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_6848aeb672ec832e816ae1f26011db51