### PR TITLE
Add error handling for async API calls

### DIFF
--- a/pages/ProfileCustomizationPage.tsx
+++ b/pages/ProfileCustomizationPage.tsx
@@ -39,11 +39,19 @@ const ProfileCustomizationPage: React.FC = () => {
   const [toast, setToast] = useState<string | null>(null);
 
   useEffect(() => {
-    setLoading(true);
-    fetchProfile().then((data) => {
-      setProfile(data);
-      setLoading(false);
-    });
+    const load = async () => {
+      setLoading(true);
+      try {
+        const data = await fetchProfile();
+        setProfile(data);
+      } catch (e) {
+        console.error(e);
+        setToast('Ошибка загрузки профиля');
+      } finally {
+        setLoading(false);
+      }
+    };
+    void load();
   }, []);
 
 


### PR DESCRIPTION
## Summary
- wrap profile fetch in `ProfileCustomizationPage` with try/catch and show toast
- handle errors when loading and saving profile data in `ProfileEditor`
- use `useToast` inside `useAutosave` and report any async errors

## Testing
- `npm test` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*
- `npx eslint components/ProfileEditor.tsx pages/ProfileCustomizationPage.tsx hooks/useAutosave.ts`

------
https://chatgpt.com/codex/tasks/task_e_6848aec231c4832ebfeb7a341a99e24b