### PR TITLE
Add accessibility improvements

### DIFF
--- a/components/AvatarUploader.tsx
+++ b/components/AvatarUploader.tsx
@@ -10,9 +10,10 @@ import { CroppedArea, getCroppedImg } from '../utils/cropImage'; // утилит
 
 interface Props {
   onChange?: (dataUrl: string | null) => void;
+  alt?: string;
 }
 
-export function AvatarUploader({ onChange }: Props) {
+export function AvatarUploader({ onChange, alt = 'Аватар пользователя' }: Props) {
   // Компонент для загрузки и обрезки аватара
   const [imageSrc, setImageSrc] = useState<string | null>(null); // исходное изображение
   const [crop, setCrop] = useState({ x: 0, y: 0 }); // текущая позиция кадра
@@ -96,7 +97,7 @@ export function AvatarUploader({ onChange }: Props) {
       >
         {avatar ? (
           // Превью уже сохранённого аватара
-          <img src={avatar} alt="avatar" className="w-full h-full object-cover" />
+          <img src={avatar} alt={alt} className="w-full h-full object-cover" />
         ) : (
           // Подсказка, если аватар ещё не выбран
           <span className="text-gray-500">Аватар</span>

--- a/components/BottomSheet.tsx
+++ b/components/BottomSheet.tsx
@@ -27,12 +27,22 @@ export const BottomSheet: React.FC<Props> = ({ open, onClose, children }) => {
     return () => document.removeEventListener('keydown', handleEsc);
   }, [open, onClose]);
 
+  useEffect(() => {
+    if (open) {
+      document.body.classList.add('overflow-hidden');
+      return () => document.body.classList.remove('overflow-hidden');
+    }
+  }, [open]);
+
   if (!visible) return null;
 
   return (
     <div
       className={`fixed inset-0 bg-black/30 flex items-end md:hidden transition-opacity duration-300 ${open ? 'opacity-100' : 'opacity-0 pointer-events-none'}`}
       onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      tabIndex={-1}
     >
       <div
         className={`bg-white rounded-t-lg w-full p-4 transition-transform duration-300 ${open ? 'translate-y-0' : 'translate-y-full'}`}

--- a/components/ButtonLinkEditor.tsx
+++ b/components/ButtonLinkEditor.tsx
@@ -55,7 +55,12 @@ export const ButtonLinkEditor = ({ value, url, onTextChange, onUrlChange }: Prop
         className="border px-2 py-1 rounded w-full mt-1"
       />
       {error && <p className="text-red-500 text-sm">{error}</p>}
-      <button type="button" className="px-2 py-1 bg-gray-200 rounded" onClick={() => setShowPicker(!showPicker)}>
+      <button
+        type="button"
+        className="px-2 py-1 bg-gray-200 rounded"
+        onClick={() => setShowPicker(!showPicker)}
+        aria-label="Выбрать эмодзи"
+      >
         😊
       </button>
       {showPicker && (

--- a/components/CoverUploader.tsx
+++ b/components/CoverUploader.tsx
@@ -5,9 +5,10 @@ import { CroppedArea, getCroppedImg } from '../utils/cropImage';
 
 interface Props {
   onChange?: (dataUrl: string | null) => void;
+  alt?: string;
 }
 
-export const CoverUploader: React.FC<Props> = ({ onChange }) => {
+export const CoverUploader: React.FC<Props> = ({ onChange, alt = 'Обложка профиля' }) => {
   // Загрузка обложки
   const [imageSrc, setImageSrc] = useState<string | null>(null);
   const [crop, setCrop] = useState({ x: 0, y: 0 });
@@ -82,7 +83,7 @@ export const CoverUploader: React.FC<Props> = ({ onChange }) => {
         onDrop={onDrop}
       >
         {cover ? (
-          <img src={cover} alt="cover" className="w-full h-full object-cover" />
+          <img src={cover} alt={alt} className="w-full h-full object-cover" />
         ) : (
           <span className="text-gray-500">Обложка 16:9</span>
         )}

--- a/components/ShareModal.tsx
+++ b/components/ShareModal.tsx
@@ -1,5 +1,5 @@
 // Модальное окно поделиться
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useToast } from './ToastProvider';
 import QRCode from 'qrcode';
 
@@ -12,6 +12,18 @@ export const ShareModal: React.FC<ShareModalProps> = ({ url, onClose }) => {
   // Модальное окно поделиться
   const { showSuccess, showError } = useToast();
   const [qr, setQr] = useState<string | null>(null);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handler);
+    document.body.classList.add('overflow-hidden');
+    return () => {
+      document.removeEventListener('keydown', handler);
+      document.body.classList.remove('overflow-hidden');
+    };
+  }, [onClose]);
 
   const copy = async () => {
     try {
@@ -45,8 +57,14 @@ export const ShareModal: React.FC<ShareModalProps> = ({ url, onClose }) => {
   };
 
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-      <div className="bg-white p-4 rounded shadow w-80 space-y-2">
+    <div
+      className="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
+      role="dialog"
+      aria-modal="true"
+      tabIndex={-1}
+      onClick={onClose}
+    >
+      <div className="bg-white p-4 rounded shadow w-80 space-y-2" onClick={(e) => e.stopPropagation()}>
         <h2 className="font-semibold text-lg">Поделиться</h2>
         <button className="w-full bg-gray-100 p-2 rounded" onClick={copy}>
           Копировать ссылку
@@ -54,7 +72,7 @@ export const ShareModal: React.FC<ShareModalProps> = ({ url, onClose }) => {
         <button className="w-full bg-gray-100 p-2 rounded" onClick={makeQr}>
           QR-код
         </button>
-        {qr && <img src={qr} alt="QR" className="mx-auto" />}
+        {qr && <img src={qr} alt={`QR код для ${url}`} className="mx-auto" />}
         <a
           href={`https://t.me/share/url?url=${encodeURIComponent(url)}`}
           target="_blank"

--- a/components/Toast.tsx
+++ b/components/Toast.tsx
@@ -9,7 +9,9 @@ export const Toast: React.FC<Props> = ({ message, onClose }) => (
   // Всплывающее уведомление
   <div role="alert" className="fixed bottom-2 right-2 bg-black text-white p-2 rounded">
     {message}
-    <button onClick={onClose} className="ml-2">✕</button>
+    <button onClick={onClose} className="ml-2" aria-label="Закрыть уведомление">
+      ✕
+    </button>
   </div>
 );
 

--- a/pages/AccountSettingsPage.tsx
+++ b/pages/AccountSettingsPage.tsx
@@ -377,7 +377,15 @@ const AccountSettingsPage: React.FC = () => {
                   <label className="block text-sm font-medium text-gray-700 mb-2">Аватар</label>
                   <div className="flex items-center space-x-4">
                     <div className="w-24 h-24 bg-gray-300 rounded-full flex items-center justify-center text-gray-500 overflow-hidden">
-                      {userData.avatar ? <img src={userData.avatar} alt="Avatar" className="w-full h-full object-cover" /> : 'Фото'}
+                      {userData.avatar ? (
+                        <img
+                          src={userData.avatar}
+                          alt="Аватар пользователя"
+                          className="w-full h-full object-cover"
+                        />
+                      ) : (
+                        'Фото'
+                      )}
                     </div>
                     <div>
                       <input

--- a/pages/PersonalizationPage.tsx
+++ b/pages/PersonalizationPage.tsx
@@ -48,8 +48,8 @@ const PersonalizationPage: React.FC = () => {
     <StandardPageLayout title="Редактор персонализации">
       <div className="flex flex-col lg:flex-row gap-6">
         <aside className="w-full lg:w-1/3 space-y-4">
-          <AvatarUploader onChange={setAvatarPreview} />
-          <CoverUploader onChange={setCoverPreview} />
+          <AvatarUploader onChange={setAvatarPreview} alt="Предпросмотр аватара" />
+          <CoverUploader onChange={setCoverPreview} alt="Предпросмотр обложки" />
           <SlugEditor
             value={slug}
             onChange={(s) => setSlug(s.replace(/\s+/g, '-').toLowerCase())}
@@ -77,7 +77,7 @@ const PersonalizationPage: React.FC = () => {
             {coverPreview && (
               <img
                 src={coverPreview}
-                alt="cover"
+                alt="Предпросмотр обложки"
                 className="w-full h-32 object-cover"
               />
             )}
@@ -85,7 +85,7 @@ const PersonalizationPage: React.FC = () => {
               {avatarPreview && (
                 <img
                   src={avatarPreview}
-                  alt="avatar"
+                  alt="Предпросмотр аватара"
                   className="w-24 h-24 rounded-full -mt-12 border-4 border-white"
                 />
               )}

--- a/pages/ProfileCustomizationPage.tsx
+++ b/pages/ProfileCustomizationPage.tsx
@@ -103,8 +103,14 @@ const ProfileCustomizationPage: React.FC = () => {
     <StandardPageLayout title="Персонализация профиля">
       <div className="flex flex-col lg:flex-row gap-8">
         <aside className="w-full lg:w-1/3 space-y-5">
-          <AvatarUploader onChange={(avatar) => setProfile((p) => ({ ...p, avatar }))} />
-          <CoverUploader onChange={(cover) => setProfile((p) => ({ ...p, cover }))} />
+          <AvatarUploader
+            onChange={(avatar) => setProfile((p) => ({ ...p, avatar }))}
+            alt={`Аватар ${profile.slug || 'пользователя'}`}
+          />
+          <CoverUploader
+            onChange={(cover) => setProfile((p) => ({ ...p, cover }))}
+            alt={`Обложка ${profile.slug || 'пользователя'}`}
+          />
           <SlugEditor
             value={profile.slug}
             onChange={(slug) => setProfile((p) => ({ ...p, slug: slug.replace(/\s+/g, '-').toLowerCase() }))}
@@ -184,13 +190,17 @@ const ProfileCustomizationPage: React.FC = () => {
         <main className="flex-1 bg-white rounded-xl border shadow p-6">
           <div className="overflow-hidden rounded-xl border mb-6">
             {profile.cover && (
-              <img src={profile.cover} alt="cover" className="w-full h-32 object-cover" />
+              <img
+                src={profile.cover}
+                alt={`Обложка пользователя ${profile.slug}`}
+                className="w-full h-32 object-cover"
+              />
             )}
             <div className="p-4 text-center relative">
               {profile.avatar && (
                 <img
                   src={profile.avatar}
-                  alt="avatar"
+                  alt={`Аватар ${profile.slug}`}
                   className="w-24 h-24 rounded-full border-4 border-white shadow absolute left-1/2 -translate-x-1/2 -top-12 bg-white"
                 />
               )}


### PR DESCRIPTION
## Summary
- add optional alt text to avatar and cover uploaders
- handle Escape key and body scroll for ShareModal and BottomSheet
- include ARIA labels for toast close and emoji picker
- provide alt text in profile settings pages

## Testing
- `npm test` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_6848aed2cea8832e8122bc6991aee0b7