### PR TITLE
Implement unified error handling

### DIFF
--- a/components/ErrorBoundary.tsx
+++ b/components/ErrorBoundary.tsx
@@ -21,19 +21,19 @@ export class ErrorBoundary extends React.Component<
   }
 
   handleReset = () => {
-    this.setState({ hasError: false });
+    window.location.reload();
   };
 
   render() {
     if (this.state.hasError) {
       return (
         <div className="p-4 bg-red-200 text-red-800">
-          <p>Что-то пошло не так.</p>
+          <p>Произошла непредвиденная ошибка. Перезагрузите страницу.</p>
           <button
             onClick={this.handleReset}
             className="mt-2 text-sm underline text-blue-600 hover:text-blue-800"
           >
-            Попробовать снова
+            Перезагрузить страницу
           </button>
         </div>
       );

--- a/components/ToastProvider.tsx
+++ b/components/ToastProvider.tsx
@@ -1,9 +1,16 @@
 // Провайдер уведомлений
-import React, { createContext, useContext, useState, useCallback } from 'react';
+import React, {
+  createContext,
+  useContext,
+  useState,
+  useCallback,
+  useEffect,
+} from 'react';
+import { ToastType, setToastHandler } from '../utils/toast';
 
 export interface Toast {
   id: number;
-  type: 'success' | 'error';
+  type: ToastType;
   message: string;
 }
 
@@ -11,11 +18,14 @@ interface ToastContextValue {
   toasts: Toast[];
   showSuccess: (msg: string) => void;
   showError: (msg: string) => void;
+  showWarning: (msg: string) => void;
 }
 
 const ToastContext = createContext<ToastContextValue | undefined>(undefined);
 
-export const ToastProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+export const ToastProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
   // Провайдер уведомлений
   const [toasts, setToasts] = useState<Toast[]>([]);
 
@@ -23,16 +33,24 @@ export const ToastProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     setToasts((t) => t.filter((toast) => toast.id !== id));
   }, []);
 
-  const show = useCallback((type: 'success' | 'error', msg: string) => {
-    const id = Date.now();
-    setToasts((t) => [...t, { id, type, message: msg }]);
-    setTimeout(() => remove(id), 3000);
-  }, [remove]);
+  const show = useCallback(
+    (type: ToastType, msg: string) => {
+      const id = Date.now();
+      setToasts((t) => [...t, { id, type, message: msg }]);
+      setTimeout(() => remove(id), 3000);
+    },
+    [remove]
+  );
+
+  useEffect(() => {
+    setToastHandler(show);
+  }, [show]);
 
   const ctx: ToastContextValue = {
     toasts,
     showSuccess: (msg) => show('success', msg),
     showError: (msg) => show('error', msg),
+    showWarning: (msg) => show('warning', msg),
   };
 
   return (
@@ -43,7 +61,11 @@ export const ToastProvider: React.FC<{ children: React.ReactNode }> = ({ childre
           <div
             key={t.id}
             className={`px-4 py-2 rounded shadow text-white ${
-              t.type === 'success' ? 'bg-green-600' : 'bg-red-600'
+              t.type === 'success'
+                ? 'bg-green-600'
+                : t.type === 'warning'
+                  ? 'bg-yellow-600'
+                  : 'bg-red-600'
             }`}
           >
             {t.message}

--- a/services/api.ts
+++ b/services/api.ts
@@ -5,6 +5,12 @@ export interface ApiOptions {
 }
 
 import { ZodSchema } from 'zod';
+import { showError } from '../utils/toast';
+
+export function handleApiError(error: unknown) {
+  const msg = error instanceof Error ? error.message : 'Неизвестная ошибка';
+  showError(msg);
+}
 
 export async function fetchJson<T>(
   url: string,
@@ -12,24 +18,31 @@ export async function fetchJson<T>(
   options: ApiOptions = {}
 ): Promise<T> {
   const { method = 'GET', body, headers } = options;
-  const response = await fetch(url, {
-    method,
-    headers: {
-      'Content-Type': 'application/json',
-      ...(headers || {}),
-    },
-    body: body ? JSON.stringify(body) : undefined,
-  });
-  if (!response.ok) {
-    let message = `HTTP error ${response.status}`;
-    try {
-      const err = await response.json();
-      message = err.error || message;
-    } catch {
-      /* ignore */
+  try {
+    const response = await fetch(url, {
+      method,
+      headers: {
+        'Content-Type': 'application/json',
+        ...(headers || {}),
+      },
+      body: body ? JSON.stringify(body) : undefined,
+    });
+    if (!response.ok) {
+      let message = `HTTP error ${response.status}`;
+      try {
+        const err = await response.json();
+        message = err.error || message;
+      } catch {
+        /* ignore */
+      }
+      const error = new Error(message);
+      handleApiError(error);
+      throw error;
     }
-    throw new Error(message);
+    const json = await response.json();
+    return schema.parse(json);
+  } catch (error) {
+    handleApiError(error);
+    throw error;
   }
-  const json = await response.json();
-  return schema.parse(json);
 }

--- a/utils/toast.ts
+++ b/utils/toast.ts
@@ -1,0 +1,25 @@
+export type ToastType = 'success' | 'error' | 'warning';
+
+let handler: (type: ToastType, message: string) => void = () => {};
+
+export function setToastHandler(
+  fn: (type: ToastType, message: string) => void
+) {
+  handler = fn;
+}
+
+function emit(type: ToastType, message: string) {
+  handler(type, message);
+}
+
+export function showSuccess(message: string) {
+  emit('success', message);
+}
+
+export function showError(message: string) {
+  emit('error', message);
+}
+
+export function showWarning(message: string) {
+  emit('warning', message);
+}


### PR DESCRIPTION
## Summary
- enhance ErrorBoundary with clear message and reload button
- extend ToastProvider with warning level and global handler
- add global toast utilities
- handle API errors in one place

## Testing
- `npm test` *(fails: Cannot find module '@rollup/rollup-linux-x64-gnu')*

------
https://chatgpt.com/codex/tasks/task_e_6848aee02ba0832ea1c8fa31fdffe07f