### PR TITLE
Add unit tests for custom hooks and publish button

### DIFF
--- a/__tests__/PublishProfileButton.test.tsx
+++ b/__tests__/PublishProfileButton.test.tsx
@@ -1,0 +1,43 @@
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PublishProfileButton } from '../components/PublishProfileButton';
+
+const mockCheck = vi.fn();
+const mockPublish = vi.fn();
+const mockSuccess = vi.fn();
+const mockError = vi.fn();
+
+vi.mock('../services/profile', () => ({
+  checkSlugUnique: (...args: unknown[]) => mockCheck(...args),
+  publishProfile: (...args: unknown[]) => mockPublish(...args),
+}));
+vi.mock('../components/ToastProvider', () => ({
+  useToast: () => ({ showSuccess: mockSuccess, showError: mockError }),
+}));
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  mockCheck.mockReset();
+  mockPublish.mockReset();
+  mockSuccess.mockReset();
+  mockError.mockReset();
+  vi.spyOn(window, 'confirm').mockReturnValue(true);
+});
+
+describe('PublishProfileButton', () => {
+  it('publishes when slug is free', async () => {
+    mockCheck.mockResolvedValue(true);
+    mockPublish.mockResolvedValue(undefined);
+    const { getByRole } = render(<PublishProfileButton slug="abc" data={{}} />);
+    fireEvent.click(getByRole('button', { name: /опубликовать профиль/i }));
+    await waitFor(() => expect(mockPublish).toHaveBeenCalled());
+    expect(mockSuccess).toHaveBeenCalled();
+  });
+
+  it('shows error when slug taken', async () => {
+    mockCheck.mockResolvedValue(false);
+    const { getByRole } = render(<PublishProfileButton slug="abc" data={{}} />);
+    fireEvent.click(getByRole('button', { name: /опубликовать профиль/i }));
+    await waitFor(() => expect(mockError).toHaveBeenCalledWith('Слаг занят'));
+  });
+});

--- a/__tests__/useAutosave.test.tsx
+++ b/__tests__/useAutosave.test.tsx
@@ -1,0 +1,51 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { useAutosave } from '../hooks/useAutosave';
+import * as cloud from '../services/cloud';
+
+vi.useFakeTimers();
+
+describe('useAutosave', () => {
+  it('saves state to storage', async () => {
+    const saveSpy = vi.spyOn(cloud, 'saveData').mockResolvedValue();
+    const { result, rerender } = renderHook(({ state }) => useAutosave('u1', 'p1', state), { initialProps: { state: { a: 1 } } });
+
+    rerender({ state: { a: 2 } });
+    expect(result.current.saved).toBe(false);
+
+    await vi.runAllTimersAsync();
+
+    expect(localStorage.getItem('draft_u1_p1')).toContain('"a":2');
+    expect(result.current.saved).toBe(true);
+    expect(saveSpy).toHaveBeenCalled();
+    saveSpy.mockRestore();
+  });
+
+  it('reports error if localStorage fails', async () => {
+    const setItem = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => { throw new Error('fail'); });
+    const { result, rerender } = renderHook(({ state }) => useAutosave('u1', 'p2', state), { initialProps: { state: { a: 1 } } });
+
+    rerender({ state: { a: 3 } });
+    await vi.runAllTimersAsync();
+
+    expect(result.current.saved).toBe(false);
+    setItem.mockRestore();
+  });
+
+  it('loads and clears draft', async () => {
+    const loadSpy = vi.spyOn(cloud, 'loadData').mockResolvedValue({ a: 5 });
+    const delSpy = vi.spyOn(cloud, 'deleteData').mockResolvedValue();
+    localStorage.removeItem('draft_u1_p3');
+    const { result } = renderHook(() => useAutosave('u1', 'p3', { a: 0 }));
+
+    expect(result.current.loadDraft()).toBeUndefined();
+    await Promise.resolve();
+    expect(loadSpy).toHaveBeenCalled();
+
+    act(() => result.current.clearDraft());
+    expect(localStorage.getItem('draft_u1_p3')).toBeNull();
+    expect(delSpy).toHaveBeenCalled();
+    loadSpy.mockRestore();
+    delSpy.mockRestore();
+  });
+});

--- a/__tests__/useSlugValidation.test.tsx
+++ b/__tests__/useSlugValidation.test.tsx
@@ -1,0 +1,30 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { useSlugValidation } from '../hooks/useSlugValidation';
+import * as slugService from '../services/slugService';
+
+describe('useSlugValidation', () => {
+  it('returns null for empty slug', () => {
+    const { result } = renderHook(() => useSlugValidation(''));
+    expect(result.current).toBeNull();
+  });
+
+  it('rejects invalid or reserved slug', () => {
+    const { result, rerender } = renderHook(({ slug }) => useSlugValidation(slug, ['admin']), { initialProps: { slug: 'ad' } });
+    expect(result.current).toBe(false);
+    rerender({ slug: 'admin' });
+    expect(result.current).toBe(false);
+  });
+
+  it('checks availability', async () => {
+    vi.spyOn(slugService, 'checkSlug').mockResolvedValue({ available: true });
+    const { result } = renderHook(() => useSlugValidation('my-slug'));
+    await waitFor(() => expect(result.current).toBe(true));
+  });
+
+  it('handles service failure', async () => {
+    vi.spyOn(slugService, 'checkSlug').mockRejectedValue(new Error('fail'));
+    const { result } = renderHook(() => useSlugValidation('errslug'));
+    await waitFor(() => expect(result.current).toBe(false));
+  });
+});

--- a/__tests__/useUndoRedo.test.tsx
+++ b/__tests__/useUndoRedo.test.tsx
@@ -1,0 +1,18 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { useUndoRedo } from '../hooks/useUndoRedo';
+
+describe('useUndoRedo', () => {
+  it('handles set, undo and redo', () => {
+    const { result } = renderHook(() => useUndoRedo(1));
+
+    act(() => result.current.set(2));
+    expect(result.current.state).toBe(2);
+    expect(result.current.canUndo).toBe(true);
+    act(() => result.current.undo());
+    expect(result.current.state).toBe(1);
+    expect(result.current.canRedo).toBe(true);
+    act(() => result.current.redo());
+    expect(result.current.state).toBe(2);
+  });
+});

--- a/pages/HomePage.tsx
+++ b/pages/HomePage.tsx
@@ -138,8 +138,8 @@ const HomePage: React.FC = () => {
                 </div>
               )}
             </div>
+
           </div>
-        </section>
 
         {/* How it works */}
         <section className="max-w-6xl mx-auto px-6">


### PR DESCRIPTION
## Summary
- remove stray closing tag in HomePage
- test undo/redo hook
- test autosave logic
- test slug validation hook
- test publish profile button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848aee9610c832ebd080d61698ea8a1