### PR TITLE
Make sidebar and showcase reusable

### DIFF
--- a/components/ProfileSidebar.tsx
+++ b/components/ProfileSidebar.tsx
@@ -1,17 +1,80 @@
 import React from 'react';
 import { BasisBSolidIcon } from './icons/IconComponents';
 
-export const ProfileSidebar: React.FC = () => {
+interface SocialLink {
+  href: string;
+  icon: React.ReactNode;
+  className?: string;
+}
+
+export interface ProfileSidebarProps {
+  name: string;
+  bio: string;
+  Icon?: React.FC<React.SVGProps<SVGSVGElement>>;
+  iconColor?: string;
+  avatarClassName?: string;
+  socialLinks?: SocialLink[];
+  className?: string;
+}
+
+const defaultSocialLinks: SocialLink[] = [
+  {
+    href: '#',
+    icon: (
+      <svg
+        className="w-5 h-5 text-gray-600"
+        fill="currentColor"
+        viewBox="0 0 24 24"
+      >
+        <path d="M24 4.557c-.883.392-1.832.656-2.828.775 1.017-.609 1.798-1.574 2.165-2.724-.951.564-2.005.974-3.127 1.195-.897-.957-2.178-1.555-3.594-1.555-3.179 0-5.515 2.966-4.797 6.045-4.091-.205-7.719-2.165-10.148-5.144-1.29 2.213-.669 5.108 1.523 6.574-.806-.026-1.566-.247-2.229-.616-.054 2.281 1.581 4.415 3.949 4.89-.693.188-1.452.232-2.224.084.626 1.956 2.444 3.379 4.6 3.419-2.07 1.623-4.678 2.348-7.29 2.04 2.179 1.397 4.768 2.212 7.548 2.212 9.142 0 14.307-7.721 13.995-14.646.962-.695 1.797-1.562 2.457-2.549z" />
+      </svg>
+    ),
+  },
+  {
+    href: '#',
+    icon: (
+      <svg
+        className="w-5 h-5 text-gray-600"
+        fill="currentColor"
+        viewBox="0 0 24 24"
+      >
+        <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
+      </svg>
+    ),
+  },
+  {
+    href: '#',
+    icon: (
+      <svg
+        className="w-5 h-5 text-gray-600"
+        fill="currentColor"
+        viewBox="0 0 24 24"
+      >
+        <path d="M12.017 0C5.396 0 .029 5.367.029 11.987c0 5.079 3.158 9.417 7.618 11.174-.105-.949-.199-2.403.041-3.439.219-.937 1.406-5.957 1.406-5.957s-.359-.72-.359-1.781c0-1.663.967-2.911 2.168-2.911 1.024 0 1.518.769 1.518 1.688 0 1.029-.653 2.567-.992 3.992-.285 1.193.6 2.165 1.775 2.165 2.128 0 3.768-2.245 3.768-5.487 0-2.861-2.063-4.869-5.008-4.869-3.41 0-5.409 2.562-5.409 5.199 0 1.033.394 2.143.889 2.741.099.12.112.225.085.345-.09.375-.293 1.199-.334 1.363-.053.225-.172.271-.402.165-1.495-.69-2.433-2.878-2.433-4.646 0-3.776 2.748-7.252 7.92-7.252 4.158 0 7.392 2.967 7.392 6.923 0 4.135-2.607 7.462-6.233 7.462-1.214 0-2.357-.629-2.746-1.378l-.748 2.853c-.271 1.043-1.002 2.35-1.492 3.146C9.57 23.812 10.763 24.009 12.017 24.009c6.624 0 11.99-5.367 11.99-11.988C24.007 5.367 18.641.001 12.017.001z" />
+      </svg>
+    ),
+  },
+];
+
+export const ProfileSidebar: React.FC<ProfileSidebarProps> = ({
+  name,
+  bio,
+  Icon = BasisBSolidIcon,
+  iconColor = '#3B82F6',
+  avatarClassName = 'w-[184px] h-[184px] bg-gradient-to-br from-blue-400 via-blue-500 to-blue-600 rounded-[12px] flex items-center justify-center overflow-hidden shadow-lg group-hover:shadow-xl transition-all duration-300 border border-blue-300/30',
+  socialLinks = defaultSocialLinks,
+  className = 'w-full md:max-w-[484px] md:flex-shrink-0 space-y-[36px] py-4 md:py-0',
+}) => {
   // Сайдбар публичного профиля
   return (
-    <aside className="w-full md:max-w-[484px] md:flex-shrink-0 space-y-[36px] py-4 md:py-0">
+    <aside className={className}>
       {/* Profile Image Section */}
       <div className="relative group">
-        <div className="w-[184px] h-[184px] bg-gradient-to-br from-blue-400 via-blue-500 to-blue-600 rounded-[12px] flex items-center justify-center overflow-hidden shadow-lg group-hover:shadow-xl transition-all duration-300 border border-blue-300/30">
+        <div className={avatarClassName}>
           <div className="absolute inset-0 bg-gradient-to-br from-white/20 to-transparent"></div>
-          <BasisBSolidIcon
+          <Icon
             className="w-[92px] h-[130px] text-white relative z-10 group-hover:scale-105 transition-transform duration-300"
-            innercolor="#3B82F6"
+            innercolor={iconColor}
           />
         </div>
         <div className="absolute -inset-1 bg-gradient-to-r from-blue-400 to-purple-500 rounded-[13px] opacity-0 group-hover:opacity-20 transition-opacity duration-300 -z-10"></div>
@@ -20,31 +83,26 @@ export const ProfileSidebar: React.FC = () => {
       {/* Profile Text Section */}
       <div className="space-y-[20px]">
         <h1 className="font-pragmatica text-gray-900 text-[56px] font-[750] leading-[52px] tracking-tight bg-gradient-to-r from-gray-900 to-gray-700 bg-clip-text">
-          Your name goes here
+          {name}
         </h1>
         <p className="text-gray-600 text-[19px] font-normal leading-[28px] max-w-[420px]">
-          Hipster ipsum tattooed brunch I'm baby. Stumptown chicken I'm bruh big
-          raw jomo. Hot fit literally kitsch fanny tilde celiac tote.
-          Single-origin forage raw neutra kombucha.
+          {bio}
         </p>
-        
+
         {/* Social Links */}
         <div className="flex items-center space-x-4 pt-4">
-          <a href="#" className="w-10 h-10 bg-gray-100 hover:bg-gray-200 rounded-full flex items-center justify-center transition-colors duration-200">
-            <svg className="w-5 h-5 text-gray-600" fill="currentColor" viewBox="0 0 24 24">
-              <path d="M24 4.557c-.883.392-1.832.656-2.828.775 1.017-.609 1.798-1.574 2.165-2.724-.951.564-2.005.974-3.127 1.195-.897-.957-2.178-1.555-3.594-1.555-3.179 0-5.515 2.966-4.797 6.045-4.091-.205-7.719-2.165-10.148-5.144-1.29 2.213-.669 5.108 1.523 6.574-.806-.026-1.566-.247-2.229-.616-.054 2.281 1.581 4.415 3.949 4.89-.693.188-1.452.232-2.224.084.626 1.956 2.444 3.379 4.6 3.419-2.07 1.623-4.678 2.348-7.29 2.04 2.179 1.397 4.768 2.212 7.548 2.212 9.142 0 14.307-7.721 13.995-14.646.962-.695 1.797-1.562 2.457-2.549z"/>
-            </svg>
-          </a>
-          <a href="#" className="w-10 h-10 bg-gray-100 hover:bg-gray-200 rounded-full flex items-center justify-center transition-colors duration-200">
-            <svg className="w-5 h-5 text-gray-600" fill="currentColor" viewBox="0 0 24 24">
-              <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/>
-            </svg>
-          </a>
-          <a href="#" className="w-10 h-10 bg-gray-100 hover:bg-gray-200 rounded-full flex items-center justify-center transition-colors duration-200">
-            <svg className="w-5 h-5 text-gray-600" fill="currentColor" viewBox="0 0 24 24">
-              <path d="M12.017 0C5.396 0 .029 5.367.029 11.987c0 5.079 3.158 9.417 7.618 11.174-.105-.949-.199-2.403.041-3.439.219-.937 1.406-5.957 1.406-5.957s-.359-.72-.359-1.781c0-1.663.967-2.911 2.168-2.911 1.024 0 1.518.769 1.518 1.688 0 1.029-.653 2.567-.992 3.992-.285 1.193.6 2.165 1.775 2.165 2.128 0 3.768-2.245 3.768-5.487 0-2.861-2.063-4.869-5.008-4.869-3.41 0-5.409 2.562-5.409 5.199 0 1.033.394 2.143.889 2.741.099.12.112.225.085.345-.09.375-.293 1.199-.334 1.363-.053.225-.172.271-.402.165-1.495-.69-2.433-2.878-2.433-4.646 0-3.776 2.748-7.252 7.92-7.252 4.158 0 7.392 2.967 7.392 6.923 0 4.135-2.607 7.462-6.233 7.462-1.214 0-2.357-.629-2.746-1.378l-.748 2.853c-.271 1.043-1.002 2.35-1.492 3.146C9.57 23.812 10.763 24.009 12.017 24.009c6.624 0 11.99-5.367 11.99-11.988C24.007 5.367 18.641.001 12.017.001z"/>
-            </svg>
-          </a>
+          {socialLinks.map((link, index) => (
+            <a
+              key={index}
+              href={link.href}
+              className={
+                link.className ||
+                'w-10 h-10 bg-gray-100 hover:bg-gray-200 rounded-full flex items-center justify-center transition-colors duration-200'
+              }
+            >
+              {link.icon}
+            </a>
+          ))}
         </div>
       </div>
     </aside>

--- a/components/ProjectShowcaseGrid.tsx
+++ b/components/ProjectShowcaseGrid.tsx
@@ -2,133 +2,51 @@
 import React from 'react';
 import { BentoItem } from '../types';
 import { BentoItemCard } from './BentoItemCard';
-import { FigmaPlaceholderIcon } from './icons/IconComponents';
 
-// Sample data based on the new visual design
-const showcaseDataTop: BentoItem[] = [
-  {
-    id: 'proj1',
-    variant: 'medium_text_right_image',
-    gridClass: 'md:col-span-1', // Approx based on 390px width in 820px container
-    icon: FigmaPlaceholderIcon,
-    iconBgClass: 'bg-[#3E3E3E]',
-    title: 'Link name goes here',
-    description: 'Description goes here',
-    imageUrl: 'https://placehold.co/155x147/A0A0A0/FFFFFF?text=Project1',
-    imageAlt: 'Project 1 placeholder',
-    customSize: 'Medium',
-  },
-  {
-    id: 'proj2',
-    variant: 'big_text_over_image',
-    gridClass: 'md:col-span-1 md:row-span-2', // Approx, 390px wide, 390px tall
-    icon: FigmaPlaceholderIcon,
-    iconBgClass: 'bg-[#3E3E3E]',
-    title: 'Link name goes here',
-    description: 'Description goes here',
-    imageUrl: 'https://placehold.co/362x192/C0C0C0/FFFFFF?text=Project2',
-    imageAlt: 'Project 2 placeholder',
-    customSize: 'Big',
-  },
-  {
-    id: 'proj3',
-    variant: 'big_text_over_image',
-    gridClass: 'md:col-span-1 md:row-span-2', // Approx
-    icon: FigmaPlaceholderIcon,
-    iconBgClass: 'bg-[#3E3E3E]',
-    title: 'Link name goes here',
-    description: 'Description goes here',
-    imageUrl: 'https://placehold.co/362x192/B0B0B0/FFFFFF?text=Project3',
-    imageAlt: 'Project 3 placeholder',
-    customSize: 'Big',
-  },
-];
+export interface ProjectShowcaseGridProps {
+  topItems?: BentoItem[];
+  bottomItems?: BentoItem[];
+  topTitle?: string;
+  bottomTitle?: string;
+  className?: string;
+}
 
-const showcaseDataBottom: BentoItem[] = [
-  {
-    id: 'proj4',
-    variant: 'smol_icon_text_vertical',
-    gridClass: 'md:col-span-1', // Approx 175px width
-    icon: FigmaPlaceholderIcon,
-    iconBgClass: 'bg-[#3E3E3E]',
-    title: 'Link name goes here',
-    description: 'Description goes here and this one is bit long',
-    customSize: 'Smol',
-  },
-  {
-    id: 'proj5',
-    variant: 'big_text_over_image',
-    gridClass: 'md:col-span-1 md:row-span-2', // Approx, centered "Big" card
-    icon: FigmaPlaceholderIcon,
-    iconBgClass: 'bg-[#3E3E3E]',
-    title: 'Link name goes here',
-    description: 'Description goes here',
-    imageUrl: 'https://placehold.co/362x192/D0D0D0/FFFFFF?text=Project5',
-    imageAlt: 'Project 5 placeholder',
-    customSize: 'Big',
-  },
-  {
-    id: 'proj6',
-    variant: 'smol_icon_text_vertical',
-    gridClass: 'md:col-span-1', // Approx
-    icon: FigmaPlaceholderIcon,
-    iconBgClass: 'bg-[#3E3E3E]',
-    title: 'Link name goes here',
-    description: 'Description goes here and this one is bit long',
-    customSize: 'Smol',
-  },
-];
-
-export const ProjectShowcaseGrid: React.FC = () => {
+export const ProjectShowcaseGrid: React.FC<ProjectShowcaseGridProps> = ({
+  topItems = [],
+  bottomItems = [],
+  topTitle = 'Project Showcase',
+  bottomTitle = 'Project Showcase',
+  className = 'w-full md:max-w-[820px] space-y-[24px]',
+}) => {
   // Сетка проектов
-  // The design has an 820px wide area for projects.
-  // Using a flexible grid that attempts to match the visual density.
-  // Cards have fixed widths in the design (Smol: 175px, Medium/Big: 390px).
-  // This will approximate 2 'Big' cards across or 4 'Smol' cards.
   return (
-    <div className="w-full md:max-w-[820px] space-y-[24px]">
-      {' '}
-      {/* Width from design */}
+    <div className={className}>
       <div>
         <h2 className="text-black text-[18px] font-semibold leading-[24px] mb-[20px] px-[12px] py-[12px] bg-white rounded-[8px]">
-          {' '}
-          {/* Styling from design's title bar */}
-          Project Showcase
+          {topTitle}
         </h2>
-        {/* Using a simple flex wrap for top row, then specific for bottom if needed, or a more complex grid */}
         <div className="grid grid-cols-1 md:grid-cols-2 gap-[24px] items-start">
-          {/* This layout is tricky. The design uses absolute positioning.
-              Simulating a common bento structure.
-              Left column for Proj1 and Proj3, Right for Proj2 */}
           <div className="space-y-[24px]">
-            {showcaseDataTop.find((item) => item.id === 'proj1') && (
-              <BentoItemCard
-                item={showcaseDataTop.find((item) => item.id === 'proj1')!}
-              />
+            {topItems[0] && (
+              <BentoItemCard key={topItems[0].id} item={topItems[0]} />
             )}
-            {showcaseDataTop.find((item) => item.id === 'proj3') && (
-              <BentoItemCard
-                item={showcaseDataTop.find((item) => item.id === 'proj3')!}
-              />
+            {topItems[2] && (
+              <BentoItemCard key={topItems[2].id} item={topItems[2]} />
             )}
           </div>
           <div className="space-y-[24px]">
-            {showcaseDataTop.find((item) => item.id === 'proj2') && (
-              <BentoItemCard
-                item={showcaseDataTop.find((item) => item.id === 'proj2')!}
-              />
+            {topItems[1] && (
+              <BentoItemCard key={topItems[1].id} item={topItems[1]} />
             )}
           </div>
         </div>
       </div>
       <div>
         <h2 className="text-black text-[18px] font-semibold leading-[24px] mb-[20px] px-[12px] py-[12px] bg-white rounded-[8px]">
-          Project Showcase
+          {bottomTitle}
         </h2>
         <div className="grid grid-cols-1 md:grid-cols-3 gap-[24px] items-start">
-          {' '}
-          {/* Based on 3 cards in this row in design */}
-          {showcaseDataBottom.map((item) => (
+          {bottomItems.map((item) => (
             <BentoItemCard key={item.id} item={item} />
           ))}
         </div>

--- a/components/ReactionBar.tsx
+++ b/components/ReactionBar.tsx
@@ -2,19 +2,34 @@
 import React from 'react';
 import { useAnalytics } from '../hooks/useAnalytics';
 
-const EMOJIS = ['👍', '❤️', '😂'];
+export interface ReactionBarProps {
+  /**
+   * Набор эмодзи для реакций
+   */
+  emojis?: string[];
+  /**
+   * Классы для контейнера
+   */
+  className?: string;
+  /**
+   * Классы для кнопки
+   */
+  buttonClassName?: string;
+}
 
-export const ReactionBar: React.FC = () => {
+const DEFAULT_EMOJIS = ['👍', '❤️', '😂'];
+
+export const ReactionBar: React.FC<ReactionBarProps> = ({
+  emojis = DEFAULT_EMOJIS,
+  className = 'flex gap-2 mt-4',
+  buttonClassName = 'px-2 py-1 bg-gray-100 rounded hover:bg-gray-200',
+}) => {
   // Панель реакций
   const { data, react } = useAnalytics();
   return (
-    <div className="flex gap-2 mt-4">
-      {EMOJIS.map((e) => (
-        <button
-          key={e}
-          onClick={() => react(e)}
-          className="px-2 py-1 bg-gray-100 rounded hover:bg-gray-200"
-        >
+    <div className={className}>
+      {emojis.map((e) => (
+        <button key={e} onClick={() => react(e)} className={buttonClassName}>
           {e} {data.reactions[e] || 0}
         </button>
       ))}

--- a/pages/PublicProfilePage.tsx
+++ b/pages/PublicProfilePage.tsx
@@ -18,7 +18,86 @@ import {
   GlobeAltIcon,
   WindowFilesIcon,
 } from '../components/icons/IconComponents';
-import type { ShareActionItem } from '../types';
+import type { ShareActionItem, BentoItem } from '../types';
+import { FigmaPlaceholderIcon } from '../components/icons/IconComponents';
+
+const profileName = 'Your name goes here';
+const profileBio =
+  "Hipster ipsum tattooed brunch I'm baby. Stumptown chicken I'm bruh big raw jomo. Hot fit literally kitsch fanny tilde celiac tote. Single-origin forage raw neutra kombucha.";
+
+const showcaseTop: BentoItem[] = [
+  {
+    id: 'proj1',
+    variant: 'medium_text_right_image',
+    gridClass: 'md:col-span-1',
+    icon: FigmaPlaceholderIcon,
+    iconBgClass: 'bg-[#3E3E3E]',
+    title: 'Link name goes here',
+    description: 'Description goes here',
+    imageUrl: 'https://placehold.co/155x147/A0A0A0/FFFFFF?text=Project1',
+    imageAlt: 'Project 1 placeholder',
+    customSize: 'Medium',
+  },
+  {
+    id: 'proj2',
+    variant: 'big_text_over_image',
+    gridClass: 'md:col-span-1 md:row-span-2',
+    icon: FigmaPlaceholderIcon,
+    iconBgClass: 'bg-[#3E3E3E]',
+    title: 'Link name goes here',
+    description: 'Description goes here',
+    imageUrl: 'https://placehold.co/362x192/C0C0C0/FFFFFF?text=Project2',
+    imageAlt: 'Project 2 placeholder',
+    customSize: 'Big',
+  },
+  {
+    id: 'proj3',
+    variant: 'big_text_over_image',
+    gridClass: 'md:col-span-1 md:row-span-2',
+    icon: FigmaPlaceholderIcon,
+    iconBgClass: 'bg-[#3E3E3E]',
+    title: 'Link name goes here',
+    description: 'Description goes here',
+    imageUrl: 'https://placehold.co/362x192/B0B0B0/FFFFFF?text=Project3',
+    imageAlt: 'Project 3 placeholder',
+    customSize: 'Big',
+  },
+];
+
+const showcaseBottom: BentoItem[] = [
+  {
+    id: 'proj4',
+    variant: 'smol_icon_text_vertical',
+    gridClass: 'md:col-span-1',
+    icon: FigmaPlaceholderIcon,
+    iconBgClass: 'bg-[#3E3E3E]',
+    title: 'Link name goes here',
+    description: 'Description goes here and this one is bit long',
+    customSize: 'Smol',
+  },
+  {
+    id: 'proj5',
+    variant: 'big_text_over_image',
+    gridClass: 'md:col-span-1 md:row-span-2',
+    icon: FigmaPlaceholderIcon,
+    iconBgClass: 'bg-[#3E3E3E]',
+    title: 'Link name goes here',
+    description: 'Description goes here',
+    imageUrl: 'https://placehold.co/362x192/D0D0D0/FFFFFF?text=Project5',
+    imageAlt: 'Project 5 placeholder',
+    customSize: 'Big',
+  },
+  {
+    id: 'proj6',
+    variant: 'smol_icon_text_vertical',
+    gridClass: 'md:col-span-1',
+    icon: FigmaPlaceholderIcon,
+    iconBgClass: 'bg-[#3E3E3E]',
+    title: 'Link name goes here',
+    description: 'Description goes here and this one is bit long',
+    customSize: 'Smol',
+  },
+];
 
 // This component now represents Section 5: Public Page
 
@@ -95,7 +174,12 @@ const BottomRightShareBar: React.FC = () => {
             style={{ transform: 'rotate(20deg)', filter: 'blur(10px)' }}
           ></div>
         </button>
-        {open && <ShareModal url={window.location.href} onClose={() => setOpen(false)} />}
+        {open && (
+          <ShareModal
+            url={window.location.href}
+            onClose={() => setOpen(false)}
+          />
+        )}
       </div>
       <div className="w-[2px] h-[16px] bg-[rgba(0,0,0,0.12)] rounded-full"></div>
       <div className="flex items-center gap-[4px]">
@@ -128,9 +212,12 @@ const PublicProfilePage: React.FC = () => {
   return (
     // main-content-area class gives the white bg and padding
     <div className="main-content-area relative flex flex-col md:flex-row gap-[80px]">
-      <ProfileSidebar />
+      <ProfileSidebar name={profileName} bio={profileBio} />
       <div className="flex-1">
-        <ProjectShowcaseGrid />
+        <ProjectShowcaseGrid
+          topItems={showcaseTop}
+          bottomItems={showcaseBottom}
+        />
         <ReactionBar />
         <Comments />
       </div>


### PR DESCRIPTION
## Summary
- make ReactionBar configurable via props
- refactor ProfileSidebar to get data via props
- add props to ProjectShowcaseGrid
- provide demo data from PublicProfilePage

## Testing
- `npm test` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_6848af00cbc8832e9c9c8b4049b27ac7