### PR TITLE
fix unstable usePrompt

### DIFF
--- a/pages/ProfileEditorPage.tsx
+++ b/pages/ProfileEditorPage.tsx
@@ -39,11 +39,10 @@ const ProfileEditorPage: React.FC = () => {
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
   const [editorKey, setEditorKey] = useState(0);
 
-  unstable_usePrompt(
-    hasUnsavedChanges
-      ? 'У вас есть несохраненные изменения. Покинуть страницу?'
-      : false,
-  );
+  unstable_usePrompt({
+    when: hasUnsavedChanges,
+    message: 'У вас есть несохраненные изменения. Покинуть страницу?',
+  });
 
   useEffect(() => {
     if (!loading && !isAuthenticated) {


### PR DESCRIPTION
## Summary
- fix unstable_usePrompt usage in ProfileEditorPage

## Testing
- `npm test` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_6848b3aa021c832ea445e2b5aaedc03b