### PR TITLE
Fix corrupted Profile components

### DIFF
--- a/components/ProjectShowcaseGrid.tsx
+++ b/components/ProjectShowcaseGrid.tsx
@@ -2,15 +2,62 @@
 import React from 'react';
 import { BentoItem } from '../types';
 import { BentoItemCard } from './BentoItemCard';
+import { Skeleton } from './Skeleton';
+
+interface Props {
+  top?: BentoItem[];
+  bottom?: BentoItem[];
+  loading?: boolean;
+}
+
+export const ProjectShowcaseGrid: React.FC<Props> = ({
+  top = [],
+  bottom = [],
+  loading,
+}) => {
+  // Сетка проектов
+  if (loading) {
+    return (
+      <div className="w-full md:max-w-[820px] space-y-[24px]">
+        <Skeleton className="h-40 w-full" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full md:max-w-[820px] space-y-[24px]">
+      <div>
+        <h2 className="text-black text-[18px] font-semibold leading-[24px] mb-[20px] px-[12px] py-[12px] bg-white rounded-[8px]">
+          Project Showcase
+        </h2>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-[24px] items-start">
+          <div className="space-y-[24px]">
+            {top.find((item) => item.id === 'proj1') && (
+              <BentoItemCard
+                item={top.find((item) => item.id === 'proj1') as BentoItem}
+              />
+            )}
+            {top.find((item) => item.id === 'proj3') && (
+              <BentoItemCard
+                item={top.find((item) => item.id === 'proj3') as BentoItem}
+              />
+            )}
+          </div>
+          <div className="space-y-[24px]">
+            {top.find((item) => item.id === 'proj2') && (
+              <BentoItemCard
+                item={top.find((item) => item.id === 'proj2') as BentoItem}
+              />
             )}
           </div>
         </div>
       </div>
       <div>
         <h2 className="text-black text-[18px] font-semibold leading-[24px] mb-[20px] px-[12px] py-[12px] bg-white rounded-[8px]">
-          {bottomTitle}
+          Project Showcase
         </h2>
         <div className="grid grid-cols-1 md:grid-cols-3 gap-[24px] items-start">
+          {bottom.map((item) => (
             <BentoItemCard key={item.id} item={item} />
           ))}
         </div>

--- a/pages/PublicProfilePage.tsx
+++ b/pages/PublicProfilePage.tsx
@@ -19,6 +19,16 @@ import {
   GlobeAltIcon,
   WindowFilesIcon,
 } from '../components/icons/IconComponents';
+import type { ShareActionItem, BentoItem, SocialLink } from '../types';
+import { FigmaPlaceholderIcon } from '../components/icons/IconComponents';
+
+const defaultSocials: SocialLink[] = [
+  { id: 'twitter', href: '#', icon: SettingsAltIcon },
+  { id: 'linkedin', href: '#', icon: TargetIcon },
+  { id: 'github', href: '#', icon: ChatAltIcon },
+];
+
+const defaultTopProjects: BentoItem[] = [
   {
     id: 'proj1',
     variant: 'medium_text_right_image',
@@ -57,6 +67,7 @@ import {
   },
 ];
 
+const defaultBottomProjects: BentoItem[] = [
   {
     id: 'proj4',
     variant: 'smol_icon_text_vertical',
@@ -205,6 +216,20 @@ const PublicProfilePage: React.FC = () => {
   return (
     // main-content-area class gives the white bg and padding
     <div className="main-content-area relative flex flex-col md:flex-row gap-[80px]">
+      <ProfileSidebar
+        name={profile?.name}
+        bio={profile?.bio}
+        avatarUrl={profile?.avatar}
+        socials={profile?.socials || defaultSocials}
+        loading={loading}
+      />
+      <div className="flex-1">
+        <ProjectShowcaseGrid
+          top={profile?.projectsTop || defaultTopProjects}
+          bottom={profile?.projectsBottom || defaultBottomProjects}
+          loading={loading}
+        />
+        <ReactionBar emojis={['👍', '❤️', '😂']} />
         <Comments />
       </div>
       <BottomLeftSocialBar />


### PR DESCRIPTION
## Summary
- restore `ProjectShowcaseGrid` to last correct version
- restore `PublicProfilePage` to use restored grid component

## Testing
- `npm test` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_6848b351f4e4832e8bf3534cdf59cdf9