### PR TITLE
Add SEO meta tags and sitemap

### DIFF
--- a/mock/profiles.ts
+++ b/mock/profiles.ts
@@ -1,15 +1,28 @@
 import type { PublicProfileData } from '../types';
 
+export const publicProfiles: Record<string, PublicProfileData> = {
+  dev: {
+    name: 'John Developer',
+    bio: 'Пример портфолио разработчика',
+    seoTitle: 'Портфолио разработчика John Developer',
+    seoDescription: 'Работы и ссылки разработчика John Developer',
+    seoKeywords: 'разработчик, портфолио, john developer',
+    ogImage: null,
+  },
+  designer: {
+    name: 'Jane Designer',
+    bio: 'Пример портфолио дизайнера',
+    seoTitle: 'Портфолио дизайнера Jane Designer',
+    seoDescription: 'Работы дизайнера Jane Designer',
+    seoKeywords: 'дизайнер, портфолио, jane designer',
+    ogImage: null,
+  },
+};
+
 export async function fetchPublicProfile(slug: string): Promise<PublicProfileData | null> {
-  const profiles: Record<string, PublicProfileData> = {
-    dev: {
-      name: 'John Developer',
-      bio: 'Пример портфолио разработчика',
-    },
-    designer: {
-      name: 'Jane Designer',
-      bio: 'Пример портфолио дизайнера',
-    },
-  };
-  return profiles[slug] || null;
+  return publicProfiles[slug] || null;
+}
+
+export function getPublicProfileSlugs(): string[] {
+  return Object.keys(publicProfiles);
 }

--- a/pages/PublicProfilePage.tsx
+++ b/pages/PublicProfilePage.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState } from 'react';
 import { useParams } from 'react-router-dom';
+import { Helmet } from 'react-helmet-async';
 import { ProfileSidebar } from '../components/ProfileSidebar';
 import { ProjectShowcaseGrid } from '../components/ProjectShowcaseGrid';
 import { PublishProfileButton } from '../components/PublishProfileButton';
@@ -218,9 +219,22 @@ export interface PublicProfilePageProps {
 const PublicProfilePage: React.FC<PublicProfilePageProps> = ({ initialData }) => {
   const { slug = '' } = useParams<{ slug: string }>();
   const { data: profile, loading } = usePublicProfile(slug, initialData);
+  const title = profile?.seoTitle || profile?.name || 'Профиль';
+  const description = profile?.seoDescription || profile?.bio || '';
+  const keywords = profile?.seoKeywords || profile?.name || '';
+  const ogImage = profile?.ogImage || profile?.avatar || '';
   return (
     // main-content-area class gives the white bg and padding
-    <div className="main-content-area relative flex flex-col md:flex-row gap-[80px]">
+    <>
+      <Helmet>
+        <title>{title}</title>
+        {description && <meta name="description" content={description} />}
+        {keywords && <meta name="keywords" content={keywords} />}
+        <meta property="og:title" content={title} />
+        {description && <meta property="og:description" content={description} />}
+        {ogImage && <meta property="og:image" content={ogImage} />}
+      </Helmet>
+      <div className="main-content-area relative flex flex-col md:flex-row gap-[80px]">
       <ProfileSidebar
         name={profile?.name}
         bio={profile?.bio}
@@ -242,7 +256,8 @@ const PublicProfilePage: React.FC<PublicProfilePageProps> = ({ initialData }) =>
       <div className="absolute top-4 right-4">
         <PublishProfileButton slug={slug} data={{}} />
       </div>
-    </div>
+      </div>
+    </>
   );
 };
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -10,8 +10,9 @@ import OAuth2Server from 'oauth2-server';
 import React from 'react';
 import ReactDOMServer from 'react-dom/server';
 import { StaticRouter } from 'react-router-dom/server';
+import { HelmetProvider } from 'react-helmet-async';
 import PublicProfilePage from '../pages/PublicProfilePage';
-import { fetchPublicProfile } from '../mock/profiles';
+import { fetchPublicProfile, getPublicProfileSlugs } from '../mock/profiles';
 
 process.on('uncaughtException', (err) => {
   console.error('Uncaught Exception:', err);
@@ -325,21 +326,38 @@ app.get('/api/billing', (_req, res) => {
   res.json({ tariffs, billing, history });
 });
 
+app.get('/sitemap.xml', (req, res) => {
+  const baseUrl = `${req.protocol}://${req.get('host')}`;
+  const slugs = new Set([...getPublicProfileSlugs(), ...usedSlugs]);
+  const urls = Array.from(slugs)
+    .map((slug) => `<url><loc>${baseUrl}/public-profile/${slug}</loc></url>`)
+    .join('');
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>` +
+    `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">${urls}</urlset>`;
+  res.type('application/xml').send(xml);
+});
+
 app.get('/public-profile/:slug', async (req, res) => {
   const { slug } = req.params;
   const data = await fetchPublicProfile(slug);
+  const helmetContext: { helmet?: any } = {};
   const html = ReactDOMServer.renderToString(
     React.createElement(
-      StaticRouter,
-      { location: req.url },
-      React.createElement(PublicProfilePage)
+      HelmetProvider,
+      { context: helmetContext },
+      React.createElement(
+        StaticRouter,
+        { location: req.url },
+        React.createElement(PublicProfilePage, { initialData: data })
+      )
     )
   );
+  const { helmet } = helmetContext;
   res.set('Cache-Control', 'public, max-age=300');
   res.send(
-    `<!doctype html><html lang="ru"><head><meta charset="UTF-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/><title>${
-      data?.name || 'Профиль'
-    }</title><link rel="stylesheet" href="/index.css" /></head><body><div id="root">${html}</div><script type="module" src="/index.tsx"></script></body></html>`
+    `<!doctype html><html lang="ru"><head><meta charset="UTF-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/>${
+      helmet?.title.toString() || `<title>${data?.name || 'Профиль'}</title>`
+    }${helmet?.meta.toString() || ''}<link rel="stylesheet" href="/index.css" /></head><body><div id="root">${html}</div><script type="module" src="/index.tsx"></script></body></html>`
   );
 });
 

--- a/types.ts
+++ b/types.ts
@@ -46,6 +46,14 @@ export interface PublicProfileData {
   name?: string;
   bio?: string;
   avatar?: string | null;
+  /** Индивидуальный SEO-заголовок */
+  seoTitle?: string;
+  /** Индивидуальное SEO-описание */
+  seoDescription?: string;
+  /** Ключевые слова для поисковиков */
+  seoKeywords?: string;
+  /** Картинка превью для OpenGraph */
+  ogImage?: string | null;
   socials?: SocialLink[];
   projectsTop?: BentoItem[];
   projectsBottom?: BentoItem[];


### PR DESCRIPTION
## Summary
- expand `PublicProfileData` with SEO fields
- allow mock profile data to include SEO metadata
- inject meta and OpenGraph tags via `Helmet`
- generate sitemap.xml listing public profiles
- render SSR profile page with Helmet for dynamic SEO

## Testing
- `npm test` *(fails: useI18n must be used within I18nProvider)*

------
https://chatgpt.com/codex/tasks/task_e_6849bde63d04832eae37bd6f799ef6ee