### PR TITLE
Fix missing dashboard component imports

### DIFF
--- a/pages/DashboardPage.tsx
+++ b/pages/DashboardPage.tsx
@@ -6,6 +6,9 @@ import { fetchJson } from '../services/api';
 import { z } from 'zod';
 import { Loader } from '../components/Loader';
 import { Onboarding } from '../components/Onboarding';
+import DashboardTopBar from '../components/dashboard/DashboardTopBar';
+import ProjectsSection from '../components/dashboard/ProjectsSection';
+import QuickLinksSection from '../components/dashboard/QuickLinksSection';
 
 const DashboardPage: React.FC = () => {
   const schema = z.array(


### PR DESCRIPTION
## Summary
- import dashboard components in DashboardPage

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684e1d39eb94832ea48367392d657ca6