### PR TITLE
Improve session security and remove ioredis

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "express-rate-limit": "^7.5.0",
         "express-session": "^1.17.3",
         "html2canvas": "^1.4.1",
-        "ioredis": "^5.6.1",
         "jspdf": "^3.0.1",
         "nanoid": "^5.1.5",
         "oauth2-server": "^3.1.1",
@@ -1265,12 +1264,6 @@
       "deprecated": "Use @eslint/object-schema instead",
       "dev": true,
       "license": "BSD-3-Clause"
-    },
-    "node_modules/@ioredis/commands": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz",
-      "integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==",
-      "license": "MIT"
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -4776,15 +4769,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/denque": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
-      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -6585,30 +6569,6 @@
         "loose-envify": "^1.0.0"
       }
     },
-    "node_modules/ioredis": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.6.1.tgz",
-      "integrity": "sha512-UxC0Yv1Y4WRJiGQxQkP0hfdL0/5/6YvdfOOClRgJ0qppSarkhneSa6UvkMkms0AkdGimSH3Ikqm+6mkMmX7vGA==",
-      "license": "MIT",
-      "dependencies": {
-        "@ioredis/commands": "^1.1.1",
-        "cluster-key-slot": "^1.1.0",
-        "debug": "^4.3.4",
-        "denque": "^2.1.0",
-        "lodash.defaults": "^4.2.0",
-        "lodash.isarguments": "^3.1.0",
-        "redis-errors": "^1.2.0",
-        "redis-parser": "^3.0.0",
-        "standard-as-callback": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=12.22.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ioredis"
-      }
-    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -7624,23 +7584,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/lodash.defaults": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
-      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
-      "license": "MIT"
-    },
     "node_modules/lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
       "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
-      "license": "MIT"
-    },
-    "node_modules/lodash.isarguments": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
       "license": "MIT"
     },
     "node_modules/lodash.isequal": {
@@ -9891,27 +9839,6 @@
         "node": ">= 18"
       }
     },
-    "node_modules/redis-errors": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
-      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/redis-parser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
-      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
-      "license": "MIT",
-      "dependencies": {
-        "redis-errors": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/redux": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
@@ -10586,12 +10513,6 @@
       "engines": {
         "node": ">=0.1.14"
       }
-    },
-    "node_modules/standard-as-callback": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
-      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
-      "license": "MIT"
     },
     "node_modules/statuses": {
       "version": "2.0.1",

--- a/server/app.ts
+++ b/server/app.ts
@@ -1,9 +1,9 @@
 import express from 'express';
-import session from 'express-session';
 import { initRest } from './rest';
 import { oauthRouter } from './oauth';
 import { initGraphQL } from './graphql';
 import { initSSR } from './ssr';
+import { initSession } from './sessionStore';
 
 export const app = express();
 
@@ -18,13 +18,7 @@ process.on('warning', (warning) => {
 });
 
 app.use(express.json());
-app.use(
-  session({
-    secret: process.env.SESSION_SECRET || 'keyboard cat',
-    resave: false,
-    saveUninitialized: false,
-  })
-);
+await initSession(app);
 
 app.use(oauthRouter);
 initRest(app);

--- a/server/oauth.ts
+++ b/server/oauth.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express';
 import OAuth2Server from 'oauth2-server';
-import { users } from './userStore';
+import { authenticate } from './userStore';
 
 const oauth = new OAuth2Server({
   model: {
@@ -14,8 +14,8 @@ const oauth = new OAuth2Server({
       return { ...token, client, user } as OAuth2Server.Token;
     },
     async getUser(username: string, password: string) {
-      const record = users[username];
-      if (record && record.password === password) {
+      const record = authenticate(username, password);
+      if (record) {
         return { id: record.id } as OAuth2Server.User;
       }
       return null;

--- a/server/sessionStore.ts
+++ b/server/sessionStore.ts
@@ -1,0 +1,33 @@
+import session from 'express-session';
+import { RedisStore } from 'connect-redis';
+import { createClient } from 'redis';
+
+export async function initSession(app: import('express').Express) {
+  const url = process.env.REDIS_URL;
+  if (url) {
+    const client = createClient({ url });
+    client.on('error', (err) => console.error('Redis client error', err));
+    try {
+      await client.connect();
+      const store = new RedisStore({ client });
+      app.use(
+        session({
+          store,
+          secret: process.env.SESSION_SECRET || 'keyboard cat',
+          resave: false,
+          saveUninitialized: false,
+        })
+      );
+      return;
+    } catch (err) {
+      console.warn('Failed to connect to Redis, falling back to MemoryStore');
+    }
+  }
+  app.use(
+    session({
+      secret: process.env.SESSION_SECRET || 'keyboard cat',
+      resave: false,
+      saveUninitialized: false,
+    })
+  );
+}

--- a/server/userStore.ts
+++ b/server/userStore.ts
@@ -1,9 +1,29 @@
+import { createHash } from 'node:crypto';
+
 export interface UserRecord {
   id: string;
-  password: string;
+  passwordHash: string;
+}
+
+function hashPassword(password: string): string {
+  return createHash('sha256').update(password).digest('hex');
 }
 
 export const users: Record<string, UserRecord> = {
-  user: { id: 'user', password: 'pass' },
-  test: { id: 'test', password: 'testpass' },
+  user: { id: 'user', passwordHash: hashPassword('pass') },
+  test: { id: 'test', passwordHash: hashPassword('testpass') },
 };
+
+export function addUser(email: string, password: string): UserRecord {
+  const record = { id: email, passwordHash: hashPassword(password) };
+  users[email] = record;
+  return record;
+}
+
+export function authenticate(email: string, password: string): UserRecord | null {
+  const record = users[email];
+  if (record && record.passwordHash === hashPassword(password)) {
+    return record;
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- add Redis-backed session middleware with fallback
- store hashed user passwords and provide helper functions
- remove unused ioredis dependency

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684eb3c277ac832ebe5898289ff6e315